### PR TITLE
Structured log entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,69 @@ Now every log will include these additional fields:
 // }
 ```
 
+## Log Field Grouping
+You can group different types of log fields under specific keys, making logs more organized and easier to query:
+
+```typescript
+ContextLoggerModule.forRoot({
+  groupFields: {
+    bindingsKey: 'params',    // Groups runtime bindings
+    contextKey: 'metadata'    // Groups context information
+  }
+})
+```
+
+Before grouping:
+```json
+{
+  "userId": "123",           // context field
+  "requestId": "abc",        // context field
+  "correlationId": "xyz",    // binding
+  "timestamp": "...",        // binding
+  "level": "info",
+  "msg": "User logged in"
+}
+```
+
+After grouping:
+```json
+{
+  "metadata": {              // grouped context
+    "userId": "123",
+    "requestId": "abc"
+  },
+  "params": {               // grouped bindings
+    "correlationId": "xyz",
+    "timestamp": "..."
+  },
+  "level": "info",
+  "msg": "User logged in"
+}
+```
+
+## Context Adaptation
+Transform context data before logging to standardize format, remove sensitive data, or add computed fields:
+
+```typescript
+ContextLoggerModule.forRoot({
+  contextAdapter: (context) => ({
+    ...context,
+    sensitive: undefined,           // Remove sensitive data
+    requestId: context.reqId,      // Rename fields
+    timestamp: Date.now()          // Add new fields
+  })
+})
+```
+
+## Bootstrap Logs Control
+Control NestJS framework bootstrap logs to reduce noise during startup:
+
+```typescript
+ContextLoggerModule.forRoot({
+  ignoreBootstrapLogs: true  // Suppress framework bootstrap logs
+})
+```
+
 ## Add custom context from anywhere
 Update context from anywhere in the code 🎉. The context persists throughout the entire request execution, making it available to all services and handlers within that request.
 
@@ -268,6 +331,9 @@ flowchart TB
 | `logLevel` | string | 'info' | Log level (debug, info, warn, error) |
 | `enrichContext` | Function | ```{ duration }``` | Custom context provider |
 | `exclude` | string[] | [] | Endpoints to exclude from logging |
+| `groupFields` | Object | undefined | Group log fields under specific keys |
+| `contextAdapter` | Function | undefined | Transform context before logging |
+| `ignoreBootstrapLogs` | boolean | false | Control framework bootstrap logs |
 
 # API Reference
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "nestjs-context-logger",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nestjs-context-logger",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "lodash": "^4.17.21",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -29,7 +30,6 @@
         "express": "^4.18.2",
         "fastify": "^4.0.0",
         "jest": "^29.7.0",
-        "nestjs-pino": "^3.5.0",
         "pino": "^8.0.0",
         "prettier": "^3.4.1",
         "rimraf": "^5.0.0",
@@ -41,7 +41,7 @@
       "peerDependencies": {
         "@nestjs/common": "^10.0.0",
         "@nestjs/core": "^10.0.0",
-        "nestjs-pino": "^3.5.0",
+        "nestjs-pino": ">=3.5.0",
         "pino": "^8.0.0",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.0.0"
@@ -1312,7 +1312,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
       "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -1321,7 +1320,6 @@
       "version": "10.4.13",
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.4.13.tgz",
       "integrity": "sha512-NVJ2UYMRdMkxCcwmoWP8xihpUyd1uqKR+7QqTF3m8aedufpZm8W6WbUmNkD1j/o9TxRzhKW43PemeSMigZj+Bw==",
-      "dev": true,
       "dependencies": {
         "iterare": "1.2.1",
         "tslib": "2.8.1",
@@ -2036,7 +2034,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -2258,7 +2255,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
       "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
-      "dev": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2402,7 +2398,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2550,7 +2545,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3421,7 +3415,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -3430,7 +3423,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -3698,7 +3690,6 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
       "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -4105,7 +4096,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -4383,7 +4373,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4650,7 +4639,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/iterare/-/iterare-1.2.1.tgz",
       "integrity": "sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -5427,6 +5415,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -5672,8 +5665,8 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/nestjs-pino/-/nestjs-pino-3.5.0.tgz",
       "integrity": "sha512-IWJ3dzLVjg5istcd3Cz3rVO+gmvabfVAT1YmQgzL1HnC2hkc0H6qA6k6SZ7OIwQfewuRejYfPu3TlkxwRrqxHQ==",
-      "dev": true,
       "hasInstallScript": true,
+      "peer": true,
       "engines": {
         "node": ">= 14"
       },
@@ -5766,7 +5759,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
       "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
-      "dev": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -6000,7 +5992,6 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
       "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
-      "dev": true,
       "dependencies": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
@@ -6022,7 +6013,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
       "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
-      "dev": true,
       "dependencies": {
         "readable-stream": "^4.0.0",
         "split2": "^4.0.0"
@@ -6032,7 +6022,6 @@
       "version": "8.6.1",
       "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-8.6.1.tgz",
       "integrity": "sha512-J0hiJgUExtBXP2BjrK4VB305tHXS31sCmWJ9XJo2wPkLHa1NFPuW4V9wjG27PAc2fmBCigiNhQKpvrx+kntBPA==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "get-caller-file": "^2.0.5",
@@ -6044,8 +6033,7 @@
     "node_modules/pino-std-serializers": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
-      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
-      "dev": true
+      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
     },
     "node_modules/pirates": {
       "version": "4.0.6",
@@ -6186,7 +6174,6 @@
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -6200,8 +6187,7 @@
     "node_modules/process-warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
-      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
-      "dev": true
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ=="
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -6292,8 +6278,7 @@
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
-      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
-      "dev": true
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -6329,7 +6314,6 @@
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
       "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
-      "dev": true,
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
@@ -6345,7 +6329,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
       "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
-      "dev": true,
       "engines": {
         "node": ">= 12.13.0"
       }
@@ -6532,7 +6515,6 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -6541,7 +6523,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6570,7 +6551,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
       "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -6767,7 +6747,6 @@
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
       "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
-      "dev": true,
       "dependencies": {
         "atomic-sleep": "^1.0.0"
       }
@@ -6795,7 +6774,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "dev": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -6849,7 +6827,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -7070,7 +7047,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
       "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
-      "dev": true,
       "dependencies": {
         "real-require": "^0.2.0"
       }
@@ -7180,8 +7156,7 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -7252,7 +7227,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/uid/-/uid-2.0.2.tgz",
       "integrity": "sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==",
-      "dev": true,
       "dependencies": {
         "@lukeed/csprng": "^1.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
   "devDependencies": {
     "@nestjs/common": "^10.4.12",
     "@nestjs/core": "^10.4.12",
+    "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/platform-fastify": "^10.0.0",
     "@nestjs/testing": "^10.0.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^20.17.9",
@@ -62,6 +64,8 @@
     "eslint": "^8.0.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
+    "express": "^4.18.2",
+    "fastify": "^4.0.0",
     "jest": "^29.7.0",
     "pino": "^8.0.0",
     "prettier": "^3.4.1",
@@ -69,13 +73,10 @@
     "rxjs": "^7.0.0",
     "supertest": "^7.0.0",
     "ts-jest": "^29.2.5",
-    "typescript": "^5.7.2",
-    "@nestjs/platform-express": "^10.0.0",
-    "@nestjs/platform-fastify": "^10.0.0",
-    "express": "^4.18.2",
-    "fastify": "^4.0.0"
+    "typescript": "^5.7.2"
   },
   "dependencies": {
+    "lodash": "^4.17.21",
     "uuid": "^9.0.1"
   },
   "publishConfig": {

--- a/src/context-logger.module.spec.ts
+++ b/src/context-logger.module.spec.ts
@@ -317,6 +317,19 @@ describe('ContextLoggerModule', () => {
         contextKey: 'metadata'
       });
     });
+
+    it('should configure ignoreBootstrapLogs option', async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        imports: [
+          ContextLoggerModule.forRoot({
+            ignoreBootstrapLogs: true
+          })
+        ],
+      }).compile();
+
+      const options = module.get('CONTEXT_LOGGER_OPTIONS');
+      expect(options.ignoreBootstrapLogs).toBe(true);
+    });
   });
 
   describe('forRootAsync configuration', () => {

--- a/src/context-logger.module.spec.ts
+++ b/src/context-logger.module.spec.ts
@@ -265,12 +265,11 @@ describe('ContextLoggerModule', () => {
       );
     });
 
-    it('should configure with group fields options', async () => {
+    it('should configure with group fields for both bindings and context', async () => {
       const module: TestingModule = await Test.createTestingModule({
         imports: [
           ContextLoggerModule.forRoot({
             groupFields: {
-              enabled: true,
               bindingsKey: 'params',
               contextKey: 'metadata'
             }
@@ -280,19 +279,17 @@ describe('ContextLoggerModule', () => {
 
       const options = module.get('CONTEXT_LOGGER_OPTIONS');
       expect(options.groupFields).toEqual({
-        enabled: true,
         bindingsKey: 'params',
         contextKey: 'metadata'
       });
     });
 
-    it('should merge group fields with defaults', async () => {
+    it('should configure with group fields for bindings only', async () => {
       const module: TestingModule = await Test.createTestingModule({
         imports: [
           ContextLoggerModule.forRoot({
             groupFields: {
               bindingsKey: 'params'
-              // contextKey and enabled not specified
             }
           })
         ],
@@ -301,7 +298,23 @@ describe('ContextLoggerModule', () => {
       const options = module.get('CONTEXT_LOGGER_OPTIONS');
       expect(options.groupFields).toEqual({
         bindingsKey: 'params'
-        // Don't test defaults here as they're handled by the ContextLogger class
+      });
+    });
+
+    it('should configure with group fields for context only', async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        imports: [
+          ContextLoggerModule.forRoot({
+            groupFields: {
+              contextKey: 'metadata'
+            }
+          })
+        ],
+      }).compile();
+
+      const options = module.get('CONTEXT_LOGGER_OPTIONS');
+      expect(options.groupFields).toEqual({
+        contextKey: 'metadata'
       });
     });
   });

--- a/src/context-logger.spec.ts
+++ b/src/context-logger.spec.ts
@@ -178,4 +178,70 @@ describe('ContextLogger', () => {
       );
     });
   });
+
+  describe('log entry structure', () => {
+    it('should group bindings under logBindings field', () => {
+      const logger = new ContextLogger(MODULE_NAME);
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+      logger.info('test message', { key: 'value' });
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'test message',
+          logBindings: { key: 'value' },
+        }),
+      );
+    });
+
+    it('should group context under logContext field', () => {
+      const logger = new ContextLogger(MODULE_NAME);
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+      const contextData = { user: 'john' };
+      
+      jest.spyOn(ContextStore, 'getContext').mockReturnValue(contextData);
+      logger.info('test message');
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'test message',
+          logContext: contextData,
+        }),
+      );
+    });
+
+    it('should include error under err field', () => {
+      const logger = new ContextLogger(MODULE_NAME);
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const error = new Error('test error');
+
+      logger.error('error message', error);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'error message',
+          err: error,
+        }),
+      );
+    });
+
+    it('should include all fields when available', () => {
+      const logger = new ContextLogger(MODULE_NAME);
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const error = new Error('test error');
+      const contextData = { user: 'john' };
+      
+      jest.spyOn(ContextStore, 'getContext').mockReturnValue(contextData);
+      logger.error('error message', error, { operation: 'test' });
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'error message',
+          logBindings: { operation: 'test' },
+          logContext: contextData,
+          err: error,
+        }),
+      );
+    });
+  });
 });

--- a/src/context-logger.spec.ts
+++ b/src/context-logger.spec.ts
@@ -184,161 +184,159 @@ describe('ContextLogger', () => {
   describe('log entry structure', () => {
     it('should group bindings under default bindings key when enabled', () => {
       const logger = new ContextLogger(MODULE_NAME);
-      const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
 
       logger.info('test message', { key: 'value' });
 
-        expect(spyInfo).toHaveBeenCalledWith(
-          expect.objectContaining({
-            key: 'value',
-          }),
-          'test message',
-          MODULE_NAME
-        );
-      });
-
-      it('should spread context at root level', () => {
-        const logger = new ContextLogger(MODULE_NAME);
-        const contextData = { user: 'john' };
-        
-        jest.spyOn(ContextStore, 'getContext').mockReturnValue(contextData);
-        logger.info('test message');
-
-        expect(spyInfo).toHaveBeenCalledWith(
-          expect.objectContaining({
-            user: 'john',
-          }),
-          'test message',
-          MODULE_NAME
-        );
-      });
-
-      it('should include error at root level', () => {
-        const logger = new ContextLogger(MODULE_NAME);
-        const error = new Error('test error');
-
-        logger.error('error message', error);
-
-        expect(spyError).toHaveBeenCalledWith(
-          expect.objectContaining({
-            err: error,
-          }),
-          'error message',
-          MODULE_NAME
-        );
-      });
-
-      it('should include all fields at root level', () => {
-        const logger = new ContextLogger(MODULE_NAME);
-        const error = new Error('test error');
-        const contextData = { user: 'john' };
-        
-        jest.spyOn(ContextStore, 'getContext').mockReturnValue(contextData);
-        logger.error('error message', error, { operation: 'test' });
-
-        expect(spyError).toHaveBeenCalledWith(
-          expect.objectContaining({
-            operation: 'test',
-            user: 'john',
-            err: error,
-          }),
-          'error message',
-          MODULE_NAME
-        );
-      });
+      expect(spyInfo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'value',
+        }),
+        'test message',
+        MODULE_NAME
+      );
     });
 
-    describe('with groupFields enabled', () => {
-      it('should group bindings under default key', () => {
-        const logger = new ContextLogger(MODULE_NAME);
-        logger['options'].groupFields = { enabled: true };
+    it('should spread context at root level', () => {
+      const logger = new ContextLogger(MODULE_NAME);
+      const contextData = { user: 'john' };
         
-        logger.info('test message', { key: 'value' });
+      jest.spyOn(ContextStore, 'getContext').mockReturnValue(contextData);
+      logger.info('test message');
 
-        expect(spyInfo).toHaveBeenCalledWith(
-          expect.objectContaining({
-            bindings: { key: 'value' },
-          }),
-          'test message',
-          MODULE_NAME
-        );
-      });
-
-      it('should group context under default key', () => {
-        const logger = new ContextLogger(MODULE_NAME);
-        logger['options'].groupFields = { enabled: true };
-        const contextData = { user: 'john' };
-        
-        jest.spyOn(ContextStore, 'getContext').mockReturnValue(contextData);
-        logger.info('test message');
-
-        expect(spyInfo).toHaveBeenCalledWith(
-          expect.objectContaining({
-            context: contextData,
-          }),
-          'test message',
-          MODULE_NAME
-        );
-      });
-
-      it('should use custom key names when provided', () => {
-        const logger = new ContextLogger(MODULE_NAME);
-        logger['options'].groupFields = {
-          enabled: true,
-          bindingsKey: 'params',
-          contextKey: 'metadata',
-        };
-        
-        const contextData = { user: 'john' };
-        jest.spyOn(ContextStore, 'getContext').mockReturnValue(contextData);
-        logger.info('test message', { key: 'value' });
-
-        expect(spyInfo).toHaveBeenCalledWith(
-          expect.objectContaining({
-            params: { key: 'value' },
-            metadata: contextData,
-          }),
-          'test message',
-          MODULE_NAME
-        );
-      });
+      expect(spyInfo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user: 'john',
+        }),
+        'test message',
+        MODULE_NAME
+      );
     });
 
-    describe('context adaptation', () => {
-      it('should adapt context when adapter is provided', () => {
-        const logger = new ContextLogger(MODULE_NAME);
-        const contextData = { user: 'john', role: 'admin' };
-        
-        logger['options'].contextAdapter = (ctx) => ({ user: ctx.user });
-        jest.spyOn(ContextStore, 'getContext').mockReturnValue(contextData);
-        
-        logger.info('test message');
+    it('should include error at root level', () => {
+      const logger = new ContextLogger(MODULE_NAME);
+      const error = new Error('test error');
 
-        expect(spyInfo).toHaveBeenCalledWith(
-          expect.objectContaining({
-            user: 'john',  // Spread at root level since groupFields is disabled by default
-          }),
-          'test message',
-          MODULE_NAME
-        );
-      });
+      logger.error('error message', error);
+
+      expect(spyError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          err: error,
+        }),
+        'error message',
+        MODULE_NAME
+      );
     });
 
-    describe('null/undefined handling', () => {
-      it('should omit null or undefined values', () => {
-        const logger = new ContextLogger(MODULE_NAME);
-        jest.spyOn(ContextStore, 'getContext').mockReturnValue({});
-        logger.info('test message');
+    it('should include all fields at root level', () => {
+      const logger = new ContextLogger(MODULE_NAME);
+      const error = new Error('test error');
+      const contextData = { user: 'john' };
+        
+      jest.spyOn(ContextStore, 'getContext').mockReturnValue(contextData);
+      logger.error('error message', error, { operation: 'test' });
 
-        expect(spyInfo).toHaveBeenCalledWith(
-          expect.not.objectContaining({
-            bindings: undefined,
-            context: undefined,
-          }),
-          'test message',
-          MODULE_NAME
-        );
-      });
+      expect(spyError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: 'test',
+          user: 'john',
+          err: error,
+        }),
+        'error message',
+        MODULE_NAME
+      );
+    });
+  });
+
+  describe('with groupFields enabled', () => {
+    it('should group bindings under default key', () => {
+      const logger = new ContextLogger(MODULE_NAME);
+      logger['options'].groupFields = { enabled: true };
+        
+      logger.info('test message', { key: 'value' });
+
+      expect(spyInfo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bindings: { key: 'value' },
+        }),
+        'test message',
+        MODULE_NAME
+      );
+    });
+
+    it('should group context under default key', () => {
+      const logger = new ContextLogger(MODULE_NAME);
+      logger['options'].groupFields = { enabled: true };
+      const contextData = { user: 'john' };
+        
+      jest.spyOn(ContextStore, 'getContext').mockReturnValue(contextData);
+      logger.info('test message');
+
+      expect(spyInfo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: contextData,
+        }),
+        'test message',
+        MODULE_NAME
+      );
+    });
+
+    it('should use custom key names when provided', () => {
+      const logger = new ContextLogger(MODULE_NAME);
+      logger['options'].groupFields = {
+        enabled: true,
+        bindingsKey: 'params',
+        contextKey: 'metadata',
+      };
+        
+      const contextData = { user: 'john' };
+      jest.spyOn(ContextStore, 'getContext').mockReturnValue(contextData);
+      logger.info('test message', { key: 'value' });
+
+      expect(spyInfo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: { key: 'value' },
+          metadata: contextData,
+        }),
+        'test message',
+        MODULE_NAME
+      );
+    });
+  });
+
+  describe('context adaptation', () => {
+    it('should adapt context when adapter is provided', () => {
+      const logger = new ContextLogger(MODULE_NAME);
+      const contextData = { user: 'john', role: 'admin' };
+        
+      logger['options'].contextAdapter = (ctx) => ({ user: ctx.user });
+      jest.spyOn(ContextStore, 'getContext').mockReturnValue(contextData);
+        
+      logger.info('test message');
+
+      expect(spyInfo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user: 'john',  // Spread at root level since groupFields is disabled by default
+        }),
+        'test message',
+        MODULE_NAME
+      );
+    });
+  });
+
+  describe('null/undefined handling', () => {
+    it('should omit null or undefined values', () => {
+      const logger = new ContextLogger(MODULE_NAME);
+      jest.spyOn(ContextStore, 'getContext').mockReturnValue({});
+      logger.info('test message');
+
+      expect(spyInfo).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          bindings: undefined,
+          context: undefined,
+        }),
+        'test message',
+        MODULE_NAME
+      );
     });
   });
 });

--- a/src/context-logger.spec.ts
+++ b/src/context-logger.spec.ts
@@ -311,4 +311,43 @@ describe('ContextLogger', () => {
       );
     });
   });
+
+  describe('bootstrap logs handling', () => {
+    it('should ignore bootstrap logs when ignoreBootstrapLogs is true', () => {
+      const logger = new ContextLogger(MODULE_NAME);
+      logger['options'].ignoreBootstrapLogs = true;
+      
+      // @ts-expect-error - Simulate bootstrap phase
+      logger.log('Mapped {/api/users, GET} route', 'RouterExplorer');
+
+      expect(spyLog).not.toHaveBeenCalled();
+    });
+
+    it('should handle bootstrap logs when ignoreBootstrapLogs is false', () => {
+      const logger = new ContextLogger(MODULE_NAME);
+      logger['options'].ignoreBootstrapLogs = false;
+      
+      // @ts-expect-error - Simulate bootstrap phase
+      logger.log('Mapped {/api/users, GET} route', 'RouterExplorer');
+
+      expect(spyLog).toHaveBeenCalledWith(
+        { component: 'RouterExplorer' },
+        'Mapped {/api/users, GET} route',
+        MODULE_NAME
+      );
+    });
+
+    it('should handle bootstrap logs by default (ignoreBootstrapLogs not set)', () => {
+      const logger = new ContextLogger(MODULE_NAME);
+      
+      // @ts-expect-error - Simulate bootstrap phase
+      logger.log('Mapped {/api/users, GET} route', 'RouterExplorer');
+
+      expect(spyLog).toHaveBeenCalledWith(
+        { component: 'RouterExplorer' },
+        'Mapped {/api/users, GET} route',
+        MODULE_NAME
+      );
+    });
+  });
 });

--- a/src/context-logger.ts
+++ b/src/context-logger.ts
@@ -15,7 +15,8 @@ export interface LogEntry {
 export class ContextLogger {
   private static internalLogger: NestJSPinoLogger;
   private options: ContextLoggerFactoryOptions = {
-    structuredLogs: {
+    groupFields: {
+      enabled: true,
       bindingsKey: 'bindings',
       contextKey: 'context',
     }
@@ -105,18 +106,23 @@ export class ContextLogger {
       ? this.options.contextAdapter(storeContext)
       : storeContext;
 
-    const { bindingsKey = 'logBindings', contextKey = 'logContext' } = 
-      this.options.structuredLogs ?? {};
+    const { enabled = true, bindingsKey = 'bindings', contextKey = 'context' } = 
+      this.options.groupFields ?? {};
 
-    const logEntry = omitBy(
-      {
+    const logEntry = enabled 
+      ? {
         message,
         [contextKey]: adaptedContext,
         [bindingsKey]: bindings,
         err: error,
-      },
-      isNil,
-    );
-    return logEntry;
+      }
+      : {
+        message,
+        ...adaptedContext,
+        ...bindings,
+        err: error,
+      };
+
+    return omitBy(logEntry, isNil);
   }
 }

--- a/src/context-logger.ts
+++ b/src/context-logger.ts
@@ -98,20 +98,13 @@ export class ContextLogger {
       ? this.options.contextAdapter(storeContext)
       : storeContext;
 
-    const { enabled: groupFieldsEnabled = false, bindingsKey = 'bindings', contextKey = 'context' } = 
-      this.options.groupFields ?? {};
+    const { bindingsKey, contextKey } = this.options.groupFields ?? {};
 
-    const logEntry = groupFieldsEnabled 
-      ? {
-        [contextKey]: adaptedContext,
-        [bindingsKey]: bindings,
-        err: error,
-      }
-      : {
-        ...adaptedContext,
-        ...bindings,
-        err: error,
-      };
+    const logEntry: LogEntry = {
+      ...(contextKey ? { [contextKey]: adaptedContext } : adaptedContext),
+      ...(bindingsKey ? { [bindingsKey]: bindings } : bindings),
+      ...(error && { err: error }),
+    };
 
     return omitBy(logEntry, isNil);
   }

--- a/src/context-logger.ts
+++ b/src/context-logger.ts
@@ -78,6 +78,11 @@ export class ContextLogger {
   }
 
   private callInternalLogger(level: string, message: string, bindings: Bindings, error?: Error | string) {
+    // If it's a bootstrap log and ignoreBootstrapLogs is true, do nothing
+    if (typeof bindings === 'string' && this.options.ignoreBootstrapLogs) {
+      return;
+    }
+
     let logObject: Record<string, any>;
     if (typeof bindings === 'string') {
       // Bootstrapping logs

--- a/src/interfaces/context-logger.interface.ts
+++ b/src/interfaces/context-logger.interface.ts
@@ -34,6 +34,14 @@ export interface ContextLoggerFactoryOptions extends Params {
   };
 
   /**
+   * When true, bootstrap logs will be ignored.
+   * This is useful for those who want to suppress NestJS framework logs during bootstrap phase coming from NestJS RouterExplorer and RoutesResolver.
+   * like "Nest application successfully started" or "Mapped {/api/users, GET} route", etc.
+   * @default false
+   */
+  ignoreBootstrapLogs?: boolean;
+
+  /**
    * Optional function to transform the context before it is included in the log entry.
    * Useful for filtering, renaming, or restructuring context data.
    * 

--- a/src/interfaces/context-logger.interface.ts
+++ b/src/interfaces/context-logger.interface.ts
@@ -2,6 +2,12 @@ import { ExecutionContext, ModuleMetadata } from '@nestjs/common';
 import { Params } from 'nestjs-pino';
 
 export interface ContextLoggerFactoryOptions extends Params {
+  pinoLogger?: any;
+  structuredLogs?: {
+    bindingsKey?: string;
+    contextKey?: string;
+  };
+  contextAdapter?: (context: Record<string, any>) => Record<string, any>;
 
   /**
    * Custom context enricher function that can be used to add custom context to the log.

--- a/src/interfaces/context-logger.interface.ts
+++ b/src/interfaces/context-logger.interface.ts
@@ -3,11 +3,43 @@ import { Params } from 'nestjs-pino';
 
 export interface ContextLoggerFactoryOptions extends Params {
   pinoLogger?: any;
+  /**
+   * Configuration for grouping log fields under specific keys.
+   * If not provided or empty, all fields will be spread at the root level.
+   * Specify keys to group specific fields:
+   * - bindingsKey: Groups runtime bindings under this key
+   * - contextKey: Groups context data under this key
+   * 
+   * @example
+   * // Group both bindings and context
+   * groupFields: { bindingsKey: 'params', contextKey: 'metadata' }
+   * 
+   * // Group only bindings, spread context at root
+   * groupFields: { bindingsKey: 'params' }
+   * 
+   * // Group only context, spread bindings at root
+   * groupFields: { contextKey: 'metadata' }
+   */
   groupFields?: {
-    enabled?: boolean;  // If false or not set, spread fields at root level
+    /**
+     * Key under which runtime bindings will be grouped.
+     * If not specified, bindings will be spread at the root level.
+     */
     bindingsKey?: string;
+    /**
+     * Key under which context data will be grouped.
+     * If not specified, context will be spread at the root level.
+     */
     contextKey?: string;
   };
+
+  /**
+   * Optional function to transform the context before it is included in the log entry.
+   * Useful for filtering, renaming, or restructuring context data.
+   * 
+   * @param context - The current context object
+   * @returns The transformed context object
+   */
   contextAdapter?: (context: Record<string, any>) => Record<string, any>;
 
   /**
@@ -20,7 +52,6 @@ export interface ContextLoggerFactoryOptions extends Params {
   enrichContext?: (
     context: ExecutionContext
   ) => Record<string, any> | Promise<Record<string, any>>;
-
 }
 
 export interface ContextLoggerAsyncOptions extends Pick<ModuleMetadata, 'imports'> {

--- a/src/interfaces/context-logger.interface.ts
+++ b/src/interfaces/context-logger.interface.ts
@@ -3,7 +3,8 @@ import { Params } from 'nestjs-pino';
 
 export interface ContextLoggerFactoryOptions extends Params {
   pinoLogger?: any;
-  structuredLogs?: {
+  groupFields?: {
+    enabled?: boolean;  // If false or not set, spread fields at root level
     bindingsKey?: string;
     contextKey?: string;
   };

--- a/src/test/context-logger.e2e.spec.ts
+++ b/src/test/context-logger.e2e.spec.ts
@@ -363,10 +363,10 @@ describe('ContextLogger E2E', () => {
         expect(mockNestJSPinoLogger.log.mock.calls[0]).toMatchObject([
           {
             correlationId: expect.any(String),
-            requestMethod: "GET",
-            requestUrl: "/simple-test",
-            environment: "test",
-            traceId: "express-trace-123",
+            requestMethod: 'GET',
+            requestUrl: '/simple-test',
+            environment: 'test',
+            traceId: 'express-trace-123',
           },
           'test endpoint hit',
           SimpleTestController.name
@@ -401,10 +401,10 @@ describe('ContextLogger E2E', () => {
         expect(mockNestJSPinoLogger.log.mock.calls[0]).toMatchObject([
           {
             correlationId: expect.any(String),
-            requestMethod: "GET",
-            requestUrl: "/simple-test",
-            environment: "test",
-            traceId: "fastify-trace-123",
+            requestMethod: 'GET',
+            requestUrl: '/simple-test',
+            environment: 'test',
+            traceId: 'fastify-trace-123',
           },
           'test endpoint hit',
           SimpleTestController.name


### PR DESCRIPTION
## What's New?

### 1. Log Field Grouping (`groupFields`)
Added the ability to group different types of log fields under specific keys, making logs more organized and easier to query:

```typescript
ContextLoggerModule.forRoot({
  groupFields: {
    bindingsKey: 'params',    // Groups runtime bindings
    contextKey: 'metadata'    // Groups context information
  }
})
```

#### Before:
```json
{
  "userId": "123",           // context field
  "requestId": "abc",        // context field
  "correlationId": "xyz",    // binding
  "timestamp": "...",        // binding
  "level": "info",
  "msg": "User logged in"
}
```

#### After:
```json
{
  "metadata": {              // grouped context
    "userId": "123",
    "requestId": "abc"
  },
  "params": {               // grouped bindings
    "correlationId": "xyz",
    "timestamp": "..."
  },
  "level": "info",
  "msg": "User logged in"
}
```

### 2. Context Adaptation (`contextAdapter`)
Added ability to transform context data before logging:

```typescript
ContextLoggerModule.forRoot({
  contextAdapter: (context) => ({
    ...context,
    sensitive: undefined,           // Remove sensitive data
    requestId: context.reqId,      // Rename fields
    timestamp: Date.now()          // Add new fields
  })
})
```

### 3. Bootstrap Logs Control (`ignoreBootstrapLogs`)
Added ability to suppress NestJS framework bootstrap logs:

```typescript
ContextLoggerModule.forRoot({
  ignoreBootstrapLogs: true  // Suppress framework bootstrap logs
})
```

#### Before:
```text
[Nest] 1234   - 2024-01-01 12:00:01   [RouterExplorer] Mapped {/api/users, GET} route
[Nest] 1234   - 2024-01-01 12:00:01   [RoutesResolver] AppController {/api}
[Nest] 1234   - 2024-01-01 12:00:02   [NestApplication] Nest application successfully started
... Your application logs ...
```

#### After:
```text
... Only your application logs ...
```


## Why These Changes?
Requested 
https://github.com/AdirD/nestjs-context-logger/issues/1

1. **Log Structure Organization**: Many logging systems and analysis tools work better with structured logs. The `groupFields` option allows teams to organize logs in a way that matches their tooling requirements.

2. **Context Control**: The `contextAdapter` provides a way to standardize log context across an application, removing sensitive data or transforming fields to match logging standards.

3. **Ignore Bootstrap logs**:  Reducing noise during application startup, and keeping logs focused on application-specific events

## Backward Compatibility

These changes are fully backward compatible:
- If `groupFields` is not provided, all fields remain at the root level (existing behavior)
- If `contextAdapter` is not provided, context is logged as-is (existing behavior)
- If `ignoreBootstrapLogs` is not provided, bootstrap logs are logged as-is (existing behavior)

## Usage Examples

### Basic Usage (No Changes Required)
```typescript
ContextLoggerModule.forRoot({})  // Maintains existing behavior
```

### Group Only Context
```typescript
ContextLoggerModule.forRoot({
  groupFields: {
    contextKey: 'context'  // Only group context fields
  }
})
```

### Transform Context
```typescript
ContextLoggerModule.forRoot({
  contextAdapter: (context) => ({
    ...context,
    environment: process.env.NODE_ENV,
    sanitized: true
  })
})
```

### Combined Usage
```typescript
ContextLoggerModule.forRoot({
  ignoreBootstrapLogs: true,
  groupFields: {
    bindingsKey: 'bindings',
    contextKey: 'context'
  },
  contextAdapter: (context) => ({
    requestId: context.reqId,
    userId: context.user?.id
  })
})
```



