### PR TITLE
fix: does not display empty objects when grouping empty bindings or context

### DIFF
--- a/src/context-logger.spec.ts
+++ b/src/context-logger.spec.ts
@@ -126,9 +126,9 @@ describe('ContextLogger', () => {
     it('should update the context', () => {
       const newContext = { key: 'value' };
       const spyUpdateContext = jest.spyOn(ContextStore, 'updateContext');
-  
+
       ContextLogger.updateContext(newContext);
-  
+
       expect(spyUpdateContext).toHaveBeenCalledWith(newContext);
     });
   });
@@ -153,12 +153,12 @@ describe('ContextLogger', () => {
     it('should handle bootstrap component logs with string bindings', () => {
       const message = 'Mapped {/api/users, GET} route';
       const component = 'RouterExplorer';
-        
+
       // @ts-expect-error - Simulate bootstrap phase
       contextLogger.log(message, component);
 
       expect(fallbackLoggerSpy).toHaveBeenCalledWith(
-        { component }, 
+        { component },
         message,
         MODULE_NAME
       );
@@ -167,12 +167,12 @@ describe('ContextLogger', () => {
     it('should handle regular bindings after bootstrap', () => {
       const message = 'Regular log';
       const bindings = { someBinding: 'value' };
-        
+
       // Initialize logger to exit bootstrap phase
       ContextLogger.init(mockLogger as any);
-        
+
       contextLogger.log(message, bindings);
-        
+
       expect(mockLogger.log).toHaveBeenCalledWith(
         { ...bindings, ...CONTEXT },
         message,
@@ -199,7 +199,7 @@ describe('ContextLogger', () => {
       it('should spread context at root level', () => {
         const logger = new ContextLogger(MODULE_NAME);
         const contextData = { user: 'john' };
-        
+
         jest.spyOn(ContextStore, 'getContext').mockReturnValue(contextData);
         logger.info('test message');
 
@@ -218,7 +218,7 @@ describe('ContextLogger', () => {
         const logger = new ContextLogger(MODULE_NAME);
         ContextLogger.init(mockLogger as any, { groupFields: { bindingsKey: 'params' } });
         const contextData = { user: 'john' };
-        
+
         jest.spyOn(ContextStore, 'getContext').mockReturnValue(contextData);
         logger.info('test message', { key: 'value' });
 
@@ -232,11 +232,26 @@ describe('ContextLogger', () => {
         );
       });
 
+      it('should not group bindings when bindingsKey provided but bindings object is empty', () => {
+        const logger = new ContextLogger(MODULE_NAME);
+        ContextLogger.init(mockLogger as any, { groupFields: { bindingsKey: 'params' } });
+        const contextData = { user: 'john' };
+
+        jest.spyOn(ContextStore, 'getContext').mockReturnValue(contextData);
+        logger.info('test message');
+
+        expect(spyInfo).toHaveBeenCalledWith(
+          { user: 'john', },
+          'test message',
+          MODULE_NAME
+        );
+      });
+
       it('should group only context when contextKey provided', () => {
         const logger = new ContextLogger(MODULE_NAME);
         ContextLogger.init(mockLogger as any, { groupFields: { contextKey: 'metadata' } });
         const contextData = { user: 'john' };
-        
+
         jest.spyOn(ContextStore, 'getContext').mockReturnValue(contextData);
         logger.info('test message', { key: 'value' });
 
@@ -245,6 +260,21 @@ describe('ContextLogger', () => {
             metadata: { user: 'john' },
             key: 'value',
           }),
+          'test message',
+          MODULE_NAME
+        );
+      });
+
+      it('should not group context when contextKey provided but context object is empty', () => {
+        const logger = new ContextLogger(MODULE_NAME);
+        ContextLogger.init(mockLogger as any, { groupFields: { contextKey: 'metadata' } });
+        const contextData = {};
+
+        jest.spyOn(ContextStore, 'getContext').mockReturnValue(contextData);
+        logger.info('test message', { key: 'value' });
+
+        expect(spyInfo).toHaveBeenCalledWith(
+          { key: 'value' },
           'test message',
           MODULE_NAME
         );
@@ -260,7 +290,7 @@ describe('ContextLogger', () => {
             contextKey: 'metadata'
           }
         });
-        
+
         const contextData = { user: 'john' };
         jest.spyOn(ContextStore, 'getContext').mockReturnValue(contextData);
         logger.info('test message', { key: 'value' });
@@ -270,6 +300,26 @@ describe('ContextLogger', () => {
             params: { key: 'value' },
             metadata: { user: 'john' },
           }),
+          'test message',
+          MODULE_NAME
+        );
+      });
+
+      it('should not add specified keys when both bindings and context are empty', () => {
+        const logger = new ContextLogger(MODULE_NAME);
+        ContextLogger.init(mockLogger as any, {
+          groupFields: {
+            bindingsKey: 'params',
+            contextKey: 'metadata'
+          }
+        });
+
+        const contextData = {};
+        jest.spyOn(ContextStore, 'getContext').mockReturnValue(contextData);
+        logger.info('test message');
+
+        expect(spyInfo).toHaveBeenCalledWith(
+          {},
           'test message',
           MODULE_NAME
         );
@@ -284,9 +334,9 @@ describe('ContextLogger', () => {
         contextAdapter: (ctx) => ({ user: ctx.user })
       });
       const contextData = { user: 'john', role: 'admin' };
-        
+
       jest.spyOn(ContextStore, 'getContext').mockReturnValue(contextData);
-        
+
       logger.info('test message');
 
       expect(spyInfo).toHaveBeenCalledWith(
@@ -320,7 +370,7 @@ describe('ContextLogger', () => {
     it('should ignore bootstrap logs when ignoreBootstrapLogs is true', () => {
       const logger = new ContextLogger(MODULE_NAME);
       ContextLogger.init(mockLogger as any, { ignoreBootstrapLogs: true });
-      
+
       // @ts-expect-error - Simulate bootstrap phase
       logger.log('Mapped {/api/users, GET} route', 'RouterExplorer');
 
@@ -330,7 +380,7 @@ describe('ContextLogger', () => {
     it('should handle bootstrap logs when ignoreBootstrapLogs is false', () => {
       const logger = new ContextLogger(MODULE_NAME);
       ContextLogger.init(mockLogger as any, { ignoreBootstrapLogs: false });
-      
+
       // @ts-expect-error - Simulate bootstrap phase
       logger.log('Mapped {/api/users, GET} route', 'RouterExplorer');
 
@@ -344,7 +394,7 @@ describe('ContextLogger', () => {
     it('should handle bootstrap logs by default (ignoreBootstrapLogs not set)', () => {
       const logger = new ContextLogger(MODULE_NAME);
       ContextLogger.init(mockLogger as any, {});
-      
+
       // @ts-expect-error - Simulate bootstrap phase
       logger.log('Mapped {/api/users, GET} route', 'RouterExplorer');
 

--- a/src/context-logger.ts
+++ b/src/context-logger.ts
@@ -1,7 +1,7 @@
 import { Logger as NestLogger } from '@nestjs/common';
 import { Logger as NestJSPinoLogger } from 'nestjs-pino';
 import { ContextStore } from './store/context-store';
-import { omitBy, isNil } from 'lodash';
+import { omitBy, isNil, isEmpty } from 'lodash';
 import { ContextLoggerFactoryOptions } from './interfaces/context-logger.interface';
 
 type Bindings = Record<string, any>;
@@ -113,21 +113,15 @@ export class ContextLogger {
       ...(error && { err: error }),
     };
 
-    return omitBy(logEntry, isNil);
-  }
-
-  private isEmptyObject(value: Bindings): boolean {
-    return value
-      && Object.keys(value).length === 0;
+    return omitBy(
+      logEntry,
+      (value) => isNil(value) || (isEmpty(value) && !(value instanceof Error))
+    );
   }
 
   private parseObject(key: string, obj: Bindings): Bindings {
     if (!key) {
       return obj;
-    }
-
-    if (this.isEmptyObject(obj)) {
-      return {};
     }
 
     return { [key]: obj };

--- a/src/context-logger.ts
+++ b/src/context-logger.ts
@@ -113,15 +113,16 @@ export class ContextLogger {
       ...(error && { err: error }),
     };
 
-    return omitBy(
-      logEntry,
-      (value) => isNil(value) || (isEmpty(value) && !(value instanceof Error))
-    );
+    return omitBy(logEntry, isNil);
   }
 
   private parseObject(key: string, obj: Bindings): Bindings {
     if (!key) {
       return obj;
+    }
+
+    if (isEmpty(obj)) {
+      return {};
     }
 
     return { [key]: obj };

--- a/src/context-logger.ts
+++ b/src/context-logger.ts
@@ -16,13 +16,13 @@ export class ContextLogger {
   private static options: ContextLoggerFactoryOptions;
   private readonly fallbackLogger = new NestLogger();
 
-  constructor(private moduleName: string) {}
+  constructor(private moduleName: string) { }
 
   static init(logger: NestJSPinoLogger, options: ContextLoggerFactoryOptions = {}): void {
     if (!ContextLogger.internalLogger) {
       ContextLogger.internalLogger = logger;
     }
-    
+
     ContextLogger.options = options;
   }
 
@@ -45,15 +45,15 @@ export class ContextLogger {
   debug(message: string, bindings?: Bindings) {
     this.callInternalLogger('debug', message, (bindings ?? {}));
   }
-  
+
   verbose(message: string, bindings?: Bindings) {
     this.callInternalLogger('verbose', message, (bindings ?? {}));
   }
-  
+
   warn(message: string, bindings?: Bindings) {
     this.callInternalLogger('warn', message, (bindings ?? {}));
   }
-  
+
   fatal(message: string, bindings?: Bindings) {
     this.callInternalLogger('fatal', message, (bindings ?? {}));
   }
@@ -97,22 +97,39 @@ export class ContextLogger {
   }
 
   private createLogEntry(
-    bindings?: Record<string, any>,
+    bindings?: Bindings,
     error?: Error | string,
   ): LogEntry {
     const storeContext = ContextStore.getContext();
-    const adaptedContext = ContextLogger.options?.contextAdapter 
+    const adaptedContext = ContextLogger.options?.contextAdapter
       ? ContextLogger.options?.contextAdapter(storeContext)
       : storeContext;
 
     const { bindingsKey, contextKey } = ContextLogger.options?.groupFields ?? {};
 
     const logEntry: LogEntry = {
-      ...(contextKey ? { [contextKey]: adaptedContext } : adaptedContext),
-      ...(bindingsKey ? { [bindingsKey]: bindings } : bindings),
+      ...this.parseObject(contextKey, adaptedContext),
+      ...this.parseObject(bindingsKey, bindings),
       ...(error && { err: error }),
     };
 
     return omitBy(logEntry, isNil);
+  }
+
+  private isEmptyObject(value: Bindings): boolean {
+    return value
+      && Object.keys(value).length === 0;
+  }
+
+  private parseObject(key: string, obj: Bindings): Bindings {
+    if (!key) {
+      return obj;
+    }
+
+    if (this.isEmptyObject(obj)) {
+      return {};
+    }
+
+    return { [key]: obj };
   }
 }


### PR DESCRIPTION
# The problem

When grouping bindings or context, the logs with no bindings or context were being displayed with an empty object.

For example using this configuration
```ts
groupFields: {
    bindingsKey: 'log_body',
    contextKey: 'log_context',
},
```
     
Will give us this log with empty bindings and context   
```ts
[17:57:28.545] INFO (24429): Application is running on port 3009
    log_context: {}
    log_body: {}
```

# The solution
When bindings or context objects are empty, the grouping will not take effect, avoiding the creation of the empty object.

```ts
[17:57:28.545] INFO (24429): Application is running on port 3009
```


# Comments
Maybe is preferable an option to handle these cases, maybe someone prefers to keep them empty anyway but I would suggest to only implement that if is asked by someone.

Also the method `isEmptyObject()` is added to the same class but maybe is better to have it in a different place, I accept any suggestion 😄 