### PR TITLE
feature: logger hook functions

### DIFF
--- a/src/context-logger.spec.ts
+++ b/src/context-logger.spec.ts
@@ -15,9 +15,9 @@ describe('ContextLogger', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    
+
     jest.spyOn(ContextStore, 'getContext').mockReturnValue(CONTEXT);
-    
+
     mockLogger = {
       log: spyLog,
       debug: spyDebug,
@@ -29,7 +29,7 @@ describe('ContextLogger', () => {
     // Reset the internal logger for each test to ensure clean state
     (ContextLogger as any).internalLogger = null;
     ContextLogger.init(mockLogger);
-    
+
     contextLogger = new ContextLogger(MODULE_NAME);
   });
 
@@ -59,7 +59,7 @@ describe('ContextLogger', () => {
 
       expect(mockLogger.log).toHaveBeenCalledWith(CONTEXT, message, MODULE_NAME);
     });
-    
+
     it('should call log method when info is called', () => {
       const message = 'Test message';
       const bindings = { someBinding: 'value' };
@@ -245,7 +245,7 @@ describe('ContextLogger', () => {
         // Reset the internal logger for each test to ensure clean state
         (ContextLogger as any).internalLogger = null;
       });
-      
+
       it('should group only bindings when bindingsKey provided', () => {
         const logger = new ContextLogger(MODULE_NAME);
         ContextLogger.init(mockLogger, { groupFields: { bindingsKey: 'params' } });
@@ -318,7 +318,7 @@ describe('ContextLogger', () => {
         // Reset the internal logger for each test to ensure clean state
         (ContextLogger as any).internalLogger = null;
       });
-      
+
       it('should group both bindings and context under specified keys', () => {
         const logger = new ContextLogger(MODULE_NAME);
         ContextLogger.init(mockLogger, {
@@ -369,7 +369,7 @@ describe('ContextLogger', () => {
       // Reset the internal logger for each test to ensure clean state
       (ContextLogger as any).internalLogger = null;
     });
-    
+
     it('should adapt context when adapter is provided', () => {
       const logger = new ContextLogger(MODULE_NAME);
       ContextLogger.init(mockLogger, {
@@ -413,7 +413,7 @@ describe('ContextLogger', () => {
       // Reset the internal logger for each test to ensure clean state
       (ContextLogger as any).internalLogger = null;
     });
-    
+
     it('should ignore bootstrap logs when ignoreBootstrapLogs is true', () => {
       const logger = new ContextLogger(MODULE_NAME);
       ContextLogger.init(mockLogger, { ignoreBootstrapLogs: true });
@@ -450,6 +450,67 @@ describe('ContextLogger', () => {
         'Mapped {/api/users, GET} route',
         MODULE_NAME
       );
+    });
+  });
+
+  describe('hook functions', () => {
+    it('should call hook function when provided', () => {
+      const logger = new ContextLogger(MODULE_NAME);
+      const logMessage = 'Test message';
+      const bindings = { someBinding: 'value' };
+      const hookSpy = jest.fn();
+
+      ContextLogger.init(mockLogger, {
+        hooks: {
+          log: [hookSpy],
+        },
+      });
+
+      logger.log(logMessage, bindings);
+
+      expect(hookSpy).toHaveBeenCalledWith(logMessage, { ...bindings, ...CONTEXT });
+    });
+
+    it('should call multiple hook function when provided', () => {
+      const logger = new ContextLogger(MODULE_NAME);
+      const logMessage = 'Test message';
+      const bindings = { someBinding: 'value' };
+      const hookSpy1 = jest.fn();
+      const hookSpy2 = jest.fn();
+      const hookSpy3 = jest.fn();
+
+      ContextLogger.init(mockLogger, {
+        hooks: {
+          log: [hookSpy1, hookSpy2, hookSpy3],
+        },
+      });
+
+      logger.log(logMessage, bindings);
+
+      expect(hookSpy1).toHaveBeenCalledWith(logMessage, { ...bindings, ...CONTEXT });
+      expect(hookSpy2).toHaveBeenCalledWith(logMessage, { ...bindings, ...CONTEXT });
+      expect(hookSpy3).toHaveBeenCalledWith(logMessage, { ...bindings, ...CONTEXT });
+    });
+
+    it('should call \'all\' hook function when provided', () => {
+      const logger = new ContextLogger(MODULE_NAME);
+      const logMessage = 'Test message';
+      const bindings = { someBinding: 'value' };
+      const hookSpy = jest.fn();
+      const allHookSpy = jest.fn();
+
+      ContextLogger.init(mockLogger, {
+        hooks: {
+          log: [hookSpy],
+          all: [allHookSpy],
+        },
+      });
+
+      logger.log(logMessage, bindings);
+      logger.debug(logMessage, bindings);
+
+      expect(hookSpy).toHaveBeenCalledTimes(1);
+      expect(allHookSpy).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/interfaces/context-logger.interface.ts
+++ b/src/interfaces/context-logger.interface.ts
@@ -62,20 +62,24 @@ export interface ContextLoggerFactoryOptions extends Params {
   ) => Record<string, any> | Promise<Record<string, any>>;
 
   /**
-   * Optional functions to run when a log is created.
-   * These functions can be used to do additional staff with the log message and bindings.
-   * For example, you can call an external service or add to a otel counter.
+   * Optional hooks to execute when a log is created.
+   * These callbacks allow you to extend logging behavior, such as reporting to external systems,
+   * incrementing metrics, or performing side effects based on log level.
+   *
+   * ⚠️ Note: All callbacks are executed **synchronously and sequentially**.
+   * This means each hook will block the next one, potentially introducing latency
+   * to the logging process. Use with caution, especially when performing async-like tasks.
    *
    * @example
    * hooks: {
    *   all: [
    *     (message: string, bindings: Bindings) => {
-   *      // do something for all logs
+   *       // do something for all logs
    *     },
    *   ],
    *   error: [
    *     (message: string, bindings: Bindings) => {
-   *      // do something for error logs
+   *       // do something specific for error logs
    *     },
    *   ],
    * }

--- a/src/interfaces/context-logger.interface.ts
+++ b/src/interfaces/context-logger.interface.ts
@@ -1,5 +1,6 @@
 import { ExecutionContext, ModuleMetadata } from '@nestjs/common';
 import { Params } from 'nestjs-pino';
+import { Bindings, LoggerHookKeys } from '../types';
 
 export interface ContextLoggerFactoryOptions extends Params {
   /**
@@ -8,14 +9,14 @@ export interface ContextLoggerFactoryOptions extends Params {
    * Specify keys to group specific fields:
    * - bindingsKey: Groups runtime bindings under this key
    * - contextKey: Groups context data under this key
-   * 
+   *
    * @example
    * // Group both bindings and context
    * groupFields: { bindingsKey: 'params', contextKey: 'metadata' }
-   * 
+   *
    * // Group only bindings, spread context at root
    * groupFields: { bindingsKey: 'params' }
-   * 
+   *
    * // Group only context, spread bindings at root
    * groupFields: { contextKey: 'metadata' }
    */
@@ -43,7 +44,7 @@ export interface ContextLoggerFactoryOptions extends Params {
   /**
    * Optional function to transform the context before it is included in the log entry.
    * Useful for filtering, renaming, or restructuring context data.
-   * 
+   *
    * @param context - The current context object
    * @returns The transformed context object
    */
@@ -59,6 +60,27 @@ export interface ContextLoggerFactoryOptions extends Params {
   enrichContext?: (
     context: ExecutionContext
   ) => Record<string, any> | Promise<Record<string, any>>;
+
+  /**
+   * Optional functions to run when a log is created.
+   * These functions can be used to do additional staff with the log message and bindings.
+   * For example, you can call an external service or add to a otel counter.
+   *
+   * @example
+   * hooks: {
+   *   all: [
+   *     (message: string, bindings: Bindings) => {
+   *      // do something for all logs
+   *     },
+   *   ],
+   *   error: [
+   *     (message: string, bindings: Bindings) => {
+   *      // do something for error logs
+   *     },
+   *   ],
+   * }
+   */
+  hooks?: Partial<Record<LoggerHookKeys, Array<(message: string, bindings: Bindings) => void>>>;
 }
 
 export interface ContextLoggerAsyncOptions extends Pick<ModuleMetadata, 'imports'> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,10 @@
+import { LogLevel } from '@nestjs/common';
+
+export type Bindings = Record<string, any>;
+
+export interface LogEntry {
+  [key: string]: any;
+  err?: Error | string;
+}
+
+export type LoggerHookKeys = LogLevel | 'all';


### PR DESCRIPTION
added the ability to add hooks functions per each log level or all of them.
hooks are passed in the options param in the module root functions.

example:
```typescript
ContextLoggerModule.forRoot({
  hooks: {
    error: [(message, bindings) => {
      generalErrorsCounter.add(1, bindings);
    }]
  }
})

```