### PR TITLE
fix: pattern exclude when no request url

### DIFF
--- a/src/interceptors/request.interceptor.spec.ts
+++ b/src/interceptors/request.interceptor.spec.ts
@@ -64,6 +64,22 @@ describe('RequestInterceptor', () => {
       );
     });
 
+    it('should handle request with empty request context', async () => {
+      const emptyRequestContext = { };
+      (mockContext.switchToHttp().getRequest as jest.Mock).mockReturnValue(emptyRequestContext);
+      
+      const observable = await interceptor.intercept(mockContext, mockCallHandler);
+      await lastValueFrom(observable);
+
+      expect(ContextLogger.updateContext).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requestMethod: undefined,
+          requestUrl: undefined
+        })
+      );
+      expect(mockLogger.debug).toHaveBeenCalled();
+    });
+
     it('should skip context and logging for excluded routes', async () => {
       mockRequest.url = '/health';
       

--- a/src/interceptors/request.interceptor.ts
+++ b/src/interceptors/request.interceptor.ts
@@ -24,10 +24,16 @@ export class RequestInterceptor implements NestInterceptor {
     next: CallHandler
   ): Promise<Observable<any>> {
     const request = context.switchToHttp().getRequest();
-    if (this.options.exclude?.some(pattern => request.url.indexOf(pattern) === 0)) {
+
+    if (
+      request.url &&
+      this.options.exclude?.some(
+        (pattern) => request.url.indexOf(pattern) === 0
+      )
+    ) {
       return next.handle();
     }
-    
+
     const startTime = new Date();
 
     // Base context


### PR DESCRIPTION
This pull request comes to solve issue of utilizing the context logger module in mixed nestjs services where the request interceptor is also invoked on controllers running kafka events (For example). 

In general when the request.url isn't existing and the module is configured to exclude routes.

The problem:
```
TypeError: Cannot read properties of undefined (reading 'indexOf')
    at /app/node_modules/.pnpm/nestjs-context-logger@1.6.0_@nestjs+common@11.0.16_class-transformer@0.5.1_class-validator@0._kd6lxe3k4jjyqgodhhwgygigzy/node_modules/nestjs-context-logger/dist/interceptors/request.interceptor.js:28:109
    at Array.some (<anonymous>)
    at RequestInterceptor.intercept (/app/node_modules/.pnpm/nestjs-context-logger@1.6.0_@nestjs+common@11.0.16_class-transformer@0.5.1_class-validator@0._kd6lxe3k4jjyqgodhhwgygigzy/node_modules/nestjs-context-logger/dist/interceptors/request.interceptor.js:28:81)
    at nextFn (/app/node_modules/.pnpm/@nestjs+core@11.0.4_@nestjs+common@11.0.16_class-transformer@0.5.1_class-validator@0.14.1_fil_rcutrhibw77yyuhivdu4r53mra/node_modules/@nestjs/core/interceptors/interceptors-consumer.js:23:36)
    at /app/node_modules/.pnpm/@nestjs+core@11.0.4_@nestjs+common@11.0.16_class-transformer@0.5.1_class-validator@0.14.1_fil_rcutrhibw77yyuhivdu4r53mra/node_modules/@nestjs/core/interceptors/interceptors-consumer.js:21:88
    at AsyncResource.runInAsyncScope (node:async_hooks:211:14)
    at bound (node:async_hooks:242:16)
    at Observable._subscribe (/app/node_modules/.pnpm/rxjs@7.8.1/node_modules/rxjs/dist/cjs/internal/observable/defer.js:8:31)
    at Observable._trySubscribe (/app/node_modules/.pnpm/rxjs@7.8.1/node_modules/rxjs/dist/cjs/internal/Observable.js:41:25)
    at /app/node_modules/.pnpm/rxjs@7.8.1/node_modules/rxjs/dist/cjs/internal/Observable.js:35:31
```


I have added a test case to support this check.