### PR TITLE
fix: `fatal` log pass error object 

### DIFF
--- a/src/context-logger.spec.ts
+++ b/src/context-logger.spec.ts
@@ -7,6 +7,7 @@ describe('ContextLogger', () => {
   const spyDebug = jest.fn();
   const spyWarn = jest.fn();
   const spyError = jest.fn();
+  const spyFatal = jest.fn();
   const MODULE_NAME = 'TestModule';
   const CONTEXT = { someContextField: 'someContextValue' };
 
@@ -24,6 +25,7 @@ describe('ContextLogger', () => {
       info: spyInfo,
       warn: spyWarn,
       error: spyError,
+      fatal: spyFatal,
     };
 
     // Reset the internal logger for each test to ensure clean state
@@ -75,41 +77,41 @@ describe('ContextLogger', () => {
     });
   });
 
-  describe('error method', () => {
-    it('should call internal logger with error message only', () => {
+  describe('error, fatal methods', () => {
+    it.each(['error', 'fatal'])('should call internal logger with error message only', (method) => {
       const message = 'Error message';
 
-      contextLogger.error(message);
+      contextLogger[method](message);
 
-      expect(mockLogger.error).toHaveBeenCalledWith(CONTEXT, message, MODULE_NAME);
+      expect(mockLogger[method]).toHaveBeenCalledWith(CONTEXT, message, MODULE_NAME);
     });
 
-    it('should call internal logger with error message and Error object', () => {
+    it.each(['error', 'fatal'])('should call internal logger with error message and Error object', (method) => {
       const message = 'Error message';
       const error = new Error('Test error');
 
-      contextLogger.error(message, error);
+      contextLogger[method](message, error);
 
-      expect(mockLogger.error).toHaveBeenCalledWith({ err: error, ...CONTEXT }, message, MODULE_NAME);
+      expect(mockLogger[method]).toHaveBeenCalledWith({ err: error, ...CONTEXT }, message, MODULE_NAME);
     });
 
-    it('should call internal logger with error message and bindings', () => {
+    it.each(['error', 'fatal'])('should call internal logger with error message and bindings', (method) => {
       const message = 'Error message';
       const bindings = { someBinding: 'value' };
 
-      contextLogger.error(message, bindings);
+      contextLogger[method](message, bindings);
 
-      expect(mockLogger.error).toHaveBeenCalledWith({ ...bindings, ...CONTEXT }, message, MODULE_NAME);
+      expect(mockLogger[method]).toHaveBeenCalledWith({ ...bindings, ...CONTEXT }, message, MODULE_NAME);
     });
 
-    it('should call internal logger with error message, Error object, and bindings', () => {
+    it.each(['error', 'fatal'])('should call internal logger with error message, Error object, and bindings', (method) => {
       const message = 'Error message';
       const error = new Error('Test error');
       const bindings = { someBinding: 'value' };
 
-      contextLogger.error(message, error, bindings);
+      contextLogger[method](message, error, bindings);
 
-      expect(mockLogger.error).toHaveBeenCalledWith(
+      expect(mockLogger[method]).toHaveBeenCalledWith(
         { err: error, ...bindings, ...CONTEXT },
         message,
         MODULE_NAME

--- a/src/context-logger.ts
+++ b/src/context-logger.ts
@@ -59,23 +59,6 @@ export class ContextLogger {
   fatal(message: string, bindings: Bindings): void;
   fatal(message: string, error: Error, bindings: Bindings): void;
   fatal(message: string, errorOrBindings?: Error | Bindings, bindings?: Bindings): void {
-    const { error, adaptedBindings } = this.processLogParameters(errorOrBindings, bindings);
-    this.callInternalLogger('fatal', message, adaptedBindings, error);
-  }
-
-  error(message: string): void;
-  error(message: string, error: Error): void;
-  error(message: string, bindings: Bindings): void;
-  error(message: string, error: Error, bindings: Bindings): void;
-  error(message: string, errorOrBindings?: Error | Bindings, bindings?: Bindings): void {
-    const { error, adaptedBindings } = this.processLogParameters(errorOrBindings, bindings);
-    this.callInternalLogger('error', message, adaptedBindings, error);
-  }
-
-  private processLogParameters(
-    errorOrBindings?: Error | Bindings,
-    bindings?: Bindings
-  ): { error: Error | undefined; adaptedBindings: Bindings } {
     let error: Error | undefined;
     const adaptedBindings: Bindings = {};
 
@@ -90,7 +73,29 @@ export class ContextLogger {
       Object.assign(adaptedBindings, errorOrBindings);
     }
 
-    return { error, adaptedBindings };
+    this.callInternalLogger('fatal', message, adaptedBindings, error);
+  }
+
+  error(message: string): void;
+  error(message: string, error: Error): void;
+  error(message: string, bindings: Bindings): void;
+  error(message: string, error: Error, bindings: Bindings): void;
+  error(message: string, errorOrBindings?: Error | Bindings, bindings?: Bindings): void {
+    let error: Error | undefined;
+    const adaptedBindings: Bindings = {};
+
+    if (errorOrBindings instanceof Error) {
+      error = errorOrBindings;
+      if (bindings) {
+        Object.assign(adaptedBindings, bindings);
+      }
+    } else if (typeof errorOrBindings === 'string') {
+      error = errorOrBindings;
+    } else if (errorOrBindings) {
+      Object.assign(adaptedBindings, errorOrBindings);
+    }
+
+    this.callInternalLogger('error', message, adaptedBindings, error);
   }
 
   private callInternalLogger(level: LogLevel, message: string, bindings: Bindings, error?: Error | string) {

--- a/src/context-logger.ts
+++ b/src/context-logger.ts
@@ -54,8 +54,25 @@ export class ContextLogger {
     this.callInternalLogger('warn', message, (bindings ?? {}));
   }
 
-  fatal(message: string, bindings?: Bindings) {
-    this.callInternalLogger('fatal', message, (bindings ?? {}));
+  fatal(message: string): void;
+  fatal(message: string, error: Error): void;
+  fatal(message: string, bindings: Bindings): void;
+  fatal(message: string, error: Error, bindings: Bindings): void;
+  fatal(message: string, errorOrBindings?: Error | Bindings, bindings?: Bindings): void {
+    let error;
+    const adaptedBindings = {};
+    if (errorOrBindings instanceof Error) {
+      error = errorOrBindings;
+      if (bindings) {
+        Object.assign(adaptedBindings, bindings);
+      }
+      // Bootstrapping logs
+    } else if (typeof errorOrBindings === 'string') {
+      error = errorOrBindings;
+    } else if (errorOrBindings) {
+      Object.assign(adaptedBindings, errorOrBindings);
+    }
+    this.callInternalLogger('fatal', message, adaptedBindings, error);
   }
 
   error(message: string): void;

--- a/src/context-logger.ts
+++ b/src/context-logger.ts
@@ -59,19 +59,7 @@ export class ContextLogger {
   fatal(message: string, bindings: Bindings): void;
   fatal(message: string, error: Error, bindings: Bindings): void;
   fatal(message: string, errorOrBindings?: Error | Bindings, bindings?: Bindings): void {
-    let error;
-    const adaptedBindings = {};
-    if (errorOrBindings instanceof Error) {
-      error = errorOrBindings;
-      if (bindings) {
-        Object.assign(adaptedBindings, bindings);
-      }
-      // Bootstrapping logs
-    } else if (typeof errorOrBindings === 'string') {
-      error = errorOrBindings;
-    } else if (errorOrBindings) {
-      Object.assign(adaptedBindings, errorOrBindings);
-    }
+    const { error, adaptedBindings } = this.processLogParameters(errorOrBindings, bindings);
     this.callInternalLogger('fatal', message, adaptedBindings, error);
   }
 
@@ -80,20 +68,29 @@ export class ContextLogger {
   error(message: string, bindings: Bindings): void;
   error(message: string, error: Error, bindings: Bindings): void;
   error(message: string, errorOrBindings?: Error | Bindings, bindings?: Bindings): void {
-    let error;
-    const adaptedBindings = {};
+    const { error, adaptedBindings } = this.processLogParameters(errorOrBindings, bindings);
+    this.callInternalLogger('error', message, adaptedBindings, error);
+  }
+
+  private processLogParameters(
+    errorOrBindings?: Error | Bindings,
+    bindings?: Bindings
+  ): { error: Error | undefined; adaptedBindings: Bindings } {
+    let error: Error | undefined;
+    const adaptedBindings: Bindings = {};
+
     if (errorOrBindings instanceof Error) {
       error = errorOrBindings;
       if (bindings) {
         Object.assign(adaptedBindings, bindings);
       }
-      // Bootstrapping logs
     } else if (typeof errorOrBindings === 'string') {
       error = errorOrBindings;
     } else if (errorOrBindings) {
       Object.assign(adaptedBindings, errorOrBindings);
     }
-    this.callInternalLogger('error', message, adaptedBindings, error);
+
+    return { error, adaptedBindings };
   }
 
   private callInternalLogger(level: LogLevel, message: string, bindings: Bindings, error?: Error | string) {


### PR DESCRIPTION
## Overview
This PR addresses an inconsistency in the logger API where the `fatal` method did not support passing an `Error` object as a parameter, unlike the `error` method. To resolve this, I have unified the logic between `fatal` and `error` methods, ensuring both now handle `Error` objects and `Bindings` consistently.

Additionally, I refactored the code to improve maintainability by extracting shared logic into a private helper method (`processLogParameters`). This reduces duplication and ensures future changes can be made in a single place.

## Changes Made
1. **Unified API for `fatal` and `error`**:
   - Both methods now accept the same parameters: `(message: string, errorOrBindings?: Error | Bindings, bindings?: Bindings)`.
   - Added support for passing an `Error` object to the `fatal` method.

2. **Refactored Shared Logic**:
   - Extracted the parameter processing logic into a private method `processLogParameters`.
   - This method handles the differentiation between `Error`, `Bindings`, and other cases (e.g., strings).

3. **Improved Type Safety**:
   - Ensured that `Bindings` is properly typed as `Record<string, any>`.
   - Added robust handling for unexpected types (e.g., strings passed as errors).

## Why This Change?
- **Consistency**: The `fatal` and `error` methods now have identical APIs, making the logger easier to use and understand.
- **Maintainability**: By centralizing shared logic in `processLogParameters`, future updates or bug fixes only need to be applied in one place.
- **Robustness**: Improved handling of edge cases, such as strings being passed as errors, ensures the logger behaves predictably.