### PR TITLE
fix: support pino v9

### DIFF
--- a/examples/nestjs10-example/package-lock.json
+++ b/examples/nestjs10-example/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nestjs11-example",
+  "name": "nestjs10-example",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "nestjs11-example",
+      "name": "nestjs10-example",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
@@ -19,10 +19,56 @@
       },
       "devDependencies": {
         "@types/node": "^20.11.0",
-        "nestjs-context-logger": "file:../../nestjs-context-logger-1.0.1.tgz",
+        "nestjs-context-logger": "file:../../",
         "pino-pretty": "^13.0.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.3.3"
+      }
+    },
+    "../..": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "uuid": "^9.0.1"
+      },
+      "devDependencies": {
+        "@nestjs/common": "^10.4.12 || ^11.0.0",
+        "@nestjs/core": "^10.4.12 || ^11.0.0",
+        "@nestjs/platform-express": "^10.0.0 || ^11.0.0",
+        "@nestjs/platform-fastify": "^10.0.0 || ^11.0.0",
+        "@nestjs/testing": "^10.0.0 || ^11.0.0",
+        "@types/jest": "^29.5.14",
+        "@types/node": "^20.17.9",
+        "@types/supertest": "^6.0.2",
+        "@types/uuid": "^10.0.0",
+        "@typescript-eslint/eslint-plugin": "^6.0.0",
+        "@typescript-eslint/parser": "^6.0.0",
+        "eslint": "^8.0.0",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-prettier": "^5.2.1",
+        "express": "^4.18.2",
+        "fastify": "^4.0.0",
+        "jest": "^29.7.0",
+        "nestjs-pino": "^4.4.0",
+        "pino": "^9.7.0",
+        "pino-http": "^10.4.0",
+        "prettier": "^3.4.1",
+        "rimraf": "^5.0.0",
+        "rxjs": "^7.0.0",
+        "supertest": "^7.0.0",
+        "ts-jest": "^29.2.5",
+        "typescript": "^5.7.2"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0",
+        "nestjs-pino": ">=3.5.0 || ^4.0.0",
+        "pino": "^8.0.0 || ^9.0.0",
+        "pino-http": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "reflect-metadata": ">=0.1.13",
+        "rxjs": "^7.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -998,12 +1044,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
-    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -1122,23 +1162,8 @@
       }
     },
     "node_modules/nestjs-context-logger": {
-      "version": "1.0.1",
-      "resolved": "file:../../nestjs-context-logger-1.0.1.tgz",
-      "integrity": "sha512-YlhcbXzMzMWqTis+n7rMthGYLtsNECu1yvFTSQEs7wfmc+Ku/FpXWwMDlsD7iHHZRMEtI4A5iNeRpcbzce7UJg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21",
-        "uuid": "^9.0.1"
-      },
-      "peerDependencies": {
-        "@nestjs/common": "^10.0.0 || ^11.0.0",
-        "@nestjs/core": "^10.0.0 || ^11.0.0",
-        "nestjs-pino": ">=3.5.0",
-        "pino": "^8.0.0",
-        "reflect-metadata": ">=0.1.13",
-        "rxjs": "^7.0.0"
-      }
+      "resolved": "../..",
+      "link": true
     },
     "node_modules/nestjs-pino": {
       "version": "4.4.0",
@@ -1957,19 +1982,6 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/examples/nestjs10-example/package.json
+++ b/examples/nestjs10-example/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.0",
-    "nestjs-context-logger": "file:../../nestjs-context-logger-1.0.1.tgz",
+    "nestjs-context-logger": "file:../../",
     "pino-pretty": "^13.0.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3"

--- a/examples/nestjs10-example/package.json
+++ b/examples/nestjs10-example/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "nestjs11-example",
+  "name": "nestjs10-example",
   "version": "1.0.0",
-  "description": "Example NestJS 11 app using nestjs-context-logger",
+  "description": "Example NestJS 10 app using nestjs-context-logger",
   "main": "dist/main.js",
   "scripts": {
     "build": "tsc",

--- a/examples/nestjs10-example/src/app.module.ts
+++ b/examples/nestjs10-example/src/app.module.ts
@@ -3,7 +3,19 @@ import { ContextLoggerModule } from 'nestjs-context-logger';
 import { AppController } from './app.controller';
 import { VersionMiddleware } from './middleware/version.middleware';
 
-// Using type assertion to handle the NestJS 10/11 compatibility issue
+@Module({
+  controllers: [AppController],
+  providers: [],
+})
+export class ExampleModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) { 
+    consumer
+      .apply(VersionMiddleware)
+      .forRoutes('*');
+  }
+}
+
+
 @Module({
   imports: [
     ContextLoggerModule.forRoot({
@@ -12,14 +24,8 @@ import { VersionMiddleware } from './middleware/version.middleware';
         level: 'info',
       },
     }),
+    ExampleModule,
   ],
-  controllers: [AppController],
   providers: [],
 })
-export class AppModule implements NestModule {
-  configure(consumer: MiddlewareConsumer) {
-    consumer
-      .apply(VersionMiddleware)
-      .forRoutes('*');
-  }
-} 
+export class AppModule {} 

--- a/examples/nestjs10-example/src/middleware/version.middleware.ts
+++ b/examples/nestjs10-example/src/middleware/version.middleware.ts
@@ -7,26 +7,35 @@ import * as fs from 'fs';
 @Injectable()
 export class VersionMiddleware implements NestMiddleware {
   private nestVersion: string;
+  private pinoVersion: string;
+  private nestjsPinoVersion: string;
 
   constructor() {
-    // Get NestJS version at runtime using a more reliable method
-    try {
-      // Try to read package.json from node_modules
-      const packageJsonPath = path.resolve('node_modules/@nestjs/core/package.json');
-      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
-      this.nestVersion = packageJson.version;
-    } catch (e) {
-      this.nestVersion = 'unknown';
-      console.error('Could not determine NestJS version', e);
-    }
+    // Get versions at runtime
+    this.nestVersion = this.getPackageVersion('@nestjs/core');
+    this.pinoVersion = this.getPackageVersion('pino');
+    this.nestjsPinoVersion = this.getPackageVersion('nestjs-pino');
     
-    console.log(`Detected NestJS version: ${this.nestVersion}`);
+    console.log(`Detected versions - NestJS: ${this.nestVersion}, Pino: ${this.pinoVersion}, NestJS-Pino: ${this.nestjsPinoVersion}`);
+  }
+
+  private getPackageVersion(packageName: string): string {
+    try {
+      const packageJsonPath = path.resolve(`node_modules/${packageName}/package.json`);
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+      return packageJson.version;
+    } catch (e) {
+      console.error(`Could not determine ${packageName} version`, e);
+      return 'unknown';
+    }
   }
 
   use(req: Request, res: Response, next: NextFunction) {
-    console.log(`Updating context nestVersion: ${this.nestVersion}`);
+    console.log(`Updating context with versions - NestJS: ${this.nestVersion}, Pino: ${this.pinoVersion}, NestJS-Pino: ${this.nestjsPinoVersion}`);
     ContextLogger.updateContext({
-      nestVersion: this.nestVersion
+      nestVersion: this.nestVersion,
+      pinoVersion: this.pinoVersion,
+      nestjsPinoVersion: this.nestjsPinoVersion
     });
     
     next();

--- a/examples/nestjs11-example/package-lock.json
+++ b/examples/nestjs11-example/package-lock.json
@@ -13,16 +13,62 @@
         "@nestjs/core": "^11.0.0",
         "@nestjs/platform-express": "^11.0.0",
         "nestjs-pino": "^4.4.0",
-        "pino": "^8.21.0",
+        "pino": "^9.7.0",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.0.0"
       },
       "devDependencies": {
         "@types/node": "^20.11.0",
-        "nestjs-context-logger": "file:../../nestjs-context-logger-1.0.1.tgz",
+        "nestjs-context-logger": "file:../..",
         "pino-pretty": "^13.0.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.3.3"
+      }
+    },
+    "../..": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "uuid": "^9.0.1"
+      },
+      "devDependencies": {
+        "@nestjs/common": "^10.4.12 || ^11.0.0",
+        "@nestjs/core": "^10.4.12 || ^11.0.0",
+        "@nestjs/platform-express": "^10.0.0 || ^11.0.0",
+        "@nestjs/platform-fastify": "^10.0.0 || ^11.0.0",
+        "@nestjs/testing": "^10.0.0 || ^11.0.0",
+        "@types/jest": "^29.5.14",
+        "@types/node": "^20.17.9",
+        "@types/supertest": "^6.0.2",
+        "@types/uuid": "^10.0.0",
+        "@typescript-eslint/eslint-plugin": "^6.0.0",
+        "@typescript-eslint/parser": "^6.0.0",
+        "eslint": "^8.0.0",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-prettier": "^5.2.1",
+        "express": "^4.18.2",
+        "fastify": "^4.0.0",
+        "jest": "^29.7.0",
+        "nestjs-pino": "^4.4.0",
+        "pino": "^9.7.0",
+        "pino-http": "^10.4.0",
+        "prettier": "^3.4.1",
+        "rimraf": "^5.0.0",
+        "rxjs": "^7.0.0",
+        "supertest": "^7.0.0",
+        "ts-jest": "^29.2.5",
+        "typescript": "^5.7.2"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0",
+        "nestjs-pino": ">=3.5.0 || ^4.0.0",
+        "pino": "^8.0.0 || ^9.0.0",
+        "pino-http": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "reflect-metadata": ">=0.1.13",
+        "rxjs": "^7.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -230,17 +276,6 @@
         "undici-types": "~6.19.2"
       }
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -296,25 +331,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/body-parser": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
@@ -332,29 +348,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -536,17 +529,6 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/dotenv": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
-      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -620,22 +602,6 @@
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "engines": {
-        "node": ">=0.8.x"
       }
     },
     "node_modules/express": {
@@ -946,12 +912,6 @@
         "node": ">=13.2.0"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
-    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -1093,23 +1053,8 @@
       }
     },
     "node_modules/nestjs-context-logger": {
-      "version": "1.0.1",
-      "resolved": "file:../../nestjs-context-logger-1.0.1.tgz",
-      "integrity": "sha512-YlhcbXzMzMWqTis+n7rMthGYLtsNECu1yvFTSQEs7wfmc+Ku/FpXWwMDlsD7iHHZRMEtI4A5iNeRpcbzce7UJg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21",
-        "uuid": "^9.0.1"
-      },
-      "peerDependencies": {
-        "@nestjs/common": "^10.0.0 || ^11.0.0",
-        "@nestjs/core": "^10.0.0 || ^11.0.0",
-        "nestjs-pino": ">=3.5.0",
-        "pino": "^8.0.0",
-        "reflect-metadata": ">=0.1.13",
-        "rxjs": "^7.0.0"
-      }
+      "resolved": "../..",
+      "link": true
     },
     "node_modules/nestjs-pino": {
       "version": "4.4.0",
@@ -1201,21 +1146,22 @@
       }
     },
     "node_modules/pino": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
-      "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.7.0.tgz",
+      "integrity": "sha512-vnMCM6xZTb1WDmLvtG2lE/2p+t9hDEIvTWJsu6FejkE62vB7gDhvzrpFR4Cw2to+9JNQxVnkAKVPA1KPB98vWg==",
+      "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
         "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^1.2.0",
-        "pino-std-serializers": "^6.0.0",
-        "process-warning": "^3.0.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
         "quick-format-unescaped": "^4.0.3",
         "real-require": "^0.2.0",
         "safe-stable-stringify": "^2.3.1",
-        "sonic-boom": "^3.7.0",
-        "thread-stream": "^2.6.0"
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
       },
       "bin": {
         "pino": "bin.js"
@@ -1239,37 +1185,6 @@
         "pino": "^9.0.0",
         "pino-std-serializers": "^7.0.0",
         "process-warning": "^4.0.0"
-      }
-    },
-    "node_modules/pino-http/node_modules/pino": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-9.6.0.tgz",
-      "integrity": "sha512-i85pKRCt4qMjZ1+L7sy2Ag4t1atFcdbEt76+7iRJn1g2BvsnRMGu9p8pivl9fs63M2kF/A0OacFZhTub+m/qMg==",
-      "peer": true,
-      "dependencies": {
-        "atomic-sleep": "^1.0.0",
-        "fast-redact": "^3.1.1",
-        "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^2.0.0",
-        "pino-std-serializers": "^7.0.0",
-        "process-warning": "^4.0.0",
-        "quick-format-unescaped": "^4.0.3",
-        "real-require": "^0.2.0",
-        "safe-stable-stringify": "^2.3.1",
-        "sonic-boom": "^4.0.1",
-        "thread-stream": "^3.0.0"
-      },
-      "bin": {
-        "pino": "bin.js"
-      }
-    },
-    "node_modules/pino-http/node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
-      "peer": true,
-      "dependencies": {
-        "real-require": "^0.2.0"
       }
     },
     "node_modules/pino-pretty": {
@@ -1299,66 +1214,23 @@
     "node_modules/pino-std-serializers": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
-      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
-      "peer": true
-    },
-    "node_modules/pino/node_modules/pino-abstract-transport": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
-      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
-      "dependencies": {
-        "readable-stream": "^4.0.0",
-        "split2": "^4.0.0"
-      }
-    },
-    "node_modules/pino/node_modules/pino-std-serializers": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
-      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA=="
     },
     "node_modules/pino/node_modules/process-warning": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
-      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ=="
-    },
-    "node_modules/pino/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/pino/node_modules/sonic-boom": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
-      "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0"
-      }
-    },
-    "node_modules/pino/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
@@ -1719,9 +1591,10 @@
       }
     },
     "node_modules/thread-stream": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
-      "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
       "dependencies": {
         "real-require": "^0.2.0"
       }
@@ -1869,19 +1742,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-    },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/examples/nestjs11-example/package.json
+++ b/examples/nestjs11-example/package.json
@@ -16,13 +16,13 @@
     "@nestjs/core": "^11.0.0",
     "@nestjs/platform-express": "^11.0.0",
     "nestjs-pino": "^4.4.0",
-    "pino": "^8.21.0",
+    "pino": "^9.7.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",
-    "nestjs-context-logger": "file:../../nestjs-context-logger-1.0.1.tgz",
+    "nestjs-context-logger": "file:../..",
     "pino-pretty": "^13.0.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3"

--- a/examples/nestjs11-example/src/main.ts
+++ b/examples/nestjs11-example/src/main.ts
@@ -3,9 +3,12 @@ import { AppModule } from './app.module';
 import { ContextLogger } from 'nestjs-context-logger';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
-  
   const logger = new ContextLogger('Bootstrap');
+  const app = await NestFactory.create(AppModule, {
+    logger: logger,
+    bufferLogs: true,
+  });
+  
   logger.log('Application started');
   
   await app.listen(3000);

--- a/examples/nestjs11-example/src/middleware/version.middleware.ts
+++ b/examples/nestjs11-example/src/middleware/version.middleware.ts
@@ -7,26 +7,35 @@ import * as fs from 'fs';
 @Injectable()
 export class VersionMiddleware implements NestMiddleware {
   private nestVersion: string;
+  private pinoVersion: string;
+  private nestjsPinoVersion: string;
 
   constructor() {
-    // Get NestJS version at runtime using a more reliable method
-    try {
-      // Try to read package.json from node_modules
-      const packageJsonPath = path.resolve('node_modules/@nestjs/core/package.json');
-      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
-      this.nestVersion = packageJson.version;
-    } catch (e) {
-      this.nestVersion = 'unknown';
-      console.error('Could not determine NestJS version', e);
-    }
+    // Get versions at runtime
+    this.nestVersion = this.getPackageVersion('@nestjs/core');
+    this.pinoVersion = this.getPackageVersion('pino');
+    this.nestjsPinoVersion = this.getPackageVersion('nestjs-pino');
     
-    console.log(`Detected NestJS version: ${this.nestVersion}`);
+    console.log(`Detected versions - NestJS: ${this.nestVersion}, Pino: ${this.pinoVersion}, NestJS-Pino: ${this.nestjsPinoVersion}`);
+  }
+
+  private getPackageVersion(packageName: string): string {
+    try {
+      const packageJsonPath = path.resolve(`node_modules/${packageName}/package.json`);
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+      return packageJson.version;
+    } catch (e) {
+      console.error(`Could not determine ${packageName} version`, e);
+      return 'unknown';
+    }
   }
 
   use(req: Request, res: Response, next: NextFunction) {
-    console.log(`Updating context nestVersion: ${this.nestVersion}`);
+    console.log(`Updating context with versions - NestJS: ${this.nestVersion}, Pino: ${this.pinoVersion}, NestJS-Pino: ${this.nestjsPinoVersion}`);
     ContextLogger.updateContext({
-      nestVersion: this.nestVersion
+      nestVersion: this.nestVersion,
+      pinoVersion: this.pinoVersion,
+      nestjsPinoVersion: this.nestjsPinoVersion
     });
     
     next();

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,11 @@
         "uuid": "^9.0.1"
       },
       "devDependencies": {
-        "@nestjs/common": "^10.4.12",
-        "@nestjs/core": "^10.4.12",
-        "@nestjs/platform-express": "^10.0.0",
-        "@nestjs/platform-fastify": "^10.0.0",
-        "@nestjs/testing": "^10.0.0",
+        "@nestjs/common": "^10.4.12 || ^11.0.0",
+        "@nestjs/core": "^10.4.12 || ^11.0.0",
+        "@nestjs/platform-express": "^10.0.0 || ^11.0.0",
+        "@nestjs/platform-fastify": "^10.0.0 || ^11.0.0",
+        "@nestjs/testing": "^10.0.0 || ^11.0.0",
         "@types/jest": "^29.5.14",
         "@types/node": "^20.17.9",
         "@types/supertest": "^6.0.2",
@@ -30,7 +30,9 @@
         "express": "^4.18.2",
         "fastify": "^4.0.0",
         "jest": "^29.7.0",
-        "pino": "^8.0.0",
+        "nestjs-pino": "^4.4.0",
+        "pino": "^9.7.0",
+        "pino-http": "^10.4.0",
         "prettier": "^3.4.1",
         "rimraf": "^5.0.0",
         "rxjs": "^7.0.0",
@@ -41,8 +43,8 @@
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "@nestjs/core": "^10.0.0 || ^11.0.0",
-        "nestjs-pino": ">=3.5.0",
-        "pino": "^8.0.0",
+        "nestjs-pino": ">=3.5.0 || ^4.0.0",
+        "pino": "^8.0.0 || ^9.0.0",
         "reflect-metadata": ">=0.1.13",
         "rxjs": "^7.0.0"
       }
@@ -1312,6 +1314,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
       "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -1320,6 +1323,7 @@
       "version": "10.4.13",
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.4.13.tgz",
       "integrity": "sha512-NVJ2UYMRdMkxCcwmoWP8xihpUyd1uqKR+7QqTF3m8aedufpZm8W6WbUmNkD1j/o9TxRzhKW43PemeSMigZj+Bw==",
+      "dev": true,
       "dependencies": {
         "iterare": "1.2.1",
         "tslib": "2.8.1",
@@ -1479,67 +1483,6 @@
         "cookie": "^0.7.0",
         "process-warning": "^3.0.0",
         "set-cookie-parser": "^2.4.1"
-      }
-    },
-    "node_modules/@nestjs/platform-fastify/node_modules/pino": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-9.5.0.tgz",
-      "integrity": "sha512-xSEmD4pLnV54t0NOUN16yCl7RIB1c5UUOse5HSyEXtBp+FgFQyPeDutc+Q2ZO7/22vImV7VfEjH/1zV2QuqvYw==",
-      "dev": true,
-      "dependencies": {
-        "atomic-sleep": "^1.0.0",
-        "fast-redact": "^3.1.1",
-        "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^2.0.0",
-        "pino-std-serializers": "^7.0.0",
-        "process-warning": "^4.0.0",
-        "quick-format-unescaped": "^4.0.3",
-        "real-require": "^0.2.0",
-        "safe-stable-stringify": "^2.3.1",
-        "sonic-boom": "^4.0.1",
-        "thread-stream": "^3.0.0"
-      },
-      "bin": {
-        "pino": "bin.js"
-      }
-    },
-    "node_modules/@nestjs/platform-fastify/node_modules/pino-abstract-transport": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
-      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
-      "dev": true,
-      "dependencies": {
-        "split2": "^4.0.0"
-      }
-    },
-    "node_modules/@nestjs/platform-fastify/node_modules/pino-std-serializers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
-      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
-      "dev": true
-    },
-    "node_modules/@nestjs/platform-fastify/node_modules/pino/node_modules/process-warning": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.0.tgz",
-      "integrity": "sha512-/MyYDxttz7DfGMMHiysAsFE4qF+pQYAA8ziO/3NcRVrQ5fSk+Mns4QZA/oRPFzvcqNoVJXQNWNAsdwBXLUkQKw==",
-      "dev": true
-    },
-    "node_modules/@nestjs/platform-fastify/node_modules/sonic-boom": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
-      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
-      "dev": true,
-      "dependencies": {
-        "atomic-sleep": "^1.0.0"
-      }
-    },
-    "node_modules/@nestjs/platform-fastify/node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
-      "dev": true,
-      "dependencies": {
-        "real-require": "^0.2.0"
       }
     },
     "node_modules/@nestjs/testing": {
@@ -2030,17 +1973,6 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
@@ -2255,6 +2187,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
       "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "dev": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2394,25 +2327,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/body-parser": {
       "version": "1.20.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
@@ -2539,29 +2453,6 @@
       "dev": true,
       "dependencies": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -3411,22 +3302,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -3690,6 +3565,7 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
       "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -3755,67 +3631,6 @@
         "cookie": "^0.7.0",
         "process-warning": "^3.0.0",
         "set-cookie-parser": "^2.4.1"
-      }
-    },
-    "node_modules/fastify/node_modules/pino": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-9.5.0.tgz",
-      "integrity": "sha512-xSEmD4pLnV54t0NOUN16yCl7RIB1c5UUOse5HSyEXtBp+FgFQyPeDutc+Q2ZO7/22vImV7VfEjH/1zV2QuqvYw==",
-      "dev": true,
-      "dependencies": {
-        "atomic-sleep": "^1.0.0",
-        "fast-redact": "^3.1.1",
-        "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^2.0.0",
-        "pino-std-serializers": "^7.0.0",
-        "process-warning": "^4.0.0",
-        "quick-format-unescaped": "^4.0.3",
-        "real-require": "^0.2.0",
-        "safe-stable-stringify": "^2.3.1",
-        "sonic-boom": "^4.0.1",
-        "thread-stream": "^3.0.0"
-      },
-      "bin": {
-        "pino": "bin.js"
-      }
-    },
-    "node_modules/fastify/node_modules/pino-abstract-transport": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
-      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
-      "dev": true,
-      "dependencies": {
-        "split2": "^4.0.0"
-      }
-    },
-    "node_modules/fastify/node_modules/pino-std-serializers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
-      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
-      "dev": true
-    },
-    "node_modules/fastify/node_modules/pino/node_modules/process-warning": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.0.tgz",
-      "integrity": "sha512-/MyYDxttz7DfGMMHiysAsFE4qF+pQYAA8ziO/3NcRVrQ5fSk+Mns4QZA/oRPFzvcqNoVJXQNWNAsdwBXLUkQKw==",
-      "dev": true
-    },
-    "node_modules/fastify/node_modules/sonic-boom": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
-      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
-      "dev": true,
-      "dependencies": {
-        "atomic-sleep": "^1.0.0"
-      }
-    },
-    "node_modules/fastify/node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
-      "dev": true,
-      "dependencies": {
-        "real-require": "^0.2.0"
       }
     },
     "node_modules/fastq": {
@@ -4096,6 +3911,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -4369,25 +4185,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4639,6 +4436,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/iterare/-/iterare-1.2.1.tgz",
       "integrity": "sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -5662,17 +5460,20 @@
       }
     },
     "node_modules/nestjs-pino": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/nestjs-pino/-/nestjs-pino-3.5.0.tgz",
-      "integrity": "sha512-IWJ3dzLVjg5istcd3Cz3rVO+gmvabfVAT1YmQgzL1HnC2hkc0H6qA6k6SZ7OIwQfewuRejYfPu3TlkxwRrqxHQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/nestjs-pino/-/nestjs-pino-4.4.0.tgz",
+      "integrity": "sha512-+GMNlcNWDRrMtlQftfcxN+5pV2C25A4wsYIY7cfRJTMW4b8IFKYReDrG1lUp5LGql9fXemmnVJ2Ww10iIkCZPQ==",
+      "dev": true,
       "hasInstallScript": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       },
       "peerDependencies": {
-        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
-        "pino-http": "^6.4.0 || ^7.0.0 || ^8.0.0"
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "pino": "^7.5.0 || ^8.0.0 || ^9.0.0",
+        "pino-http": "^6.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
+        "rxjs": "^7.1.0"
       }
     },
     "node_modules/node-fetch": {
@@ -5759,6 +5560,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
       "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "dev": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -5989,51 +5791,91 @@
       }
     },
     "node_modules/pino": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
-      "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.7.0.tgz",
+      "integrity": "sha512-vnMCM6xZTb1WDmLvtG2lE/2p+t9hDEIvTWJsu6FejkE62vB7gDhvzrpFR4Cw2to+9JNQxVnkAKVPA1KPB98vWg==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
         "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^1.2.0",
-        "pino-std-serializers": "^6.0.0",
-        "process-warning": "^3.0.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
         "quick-format-unescaped": "^4.0.3",
         "real-require": "^0.2.0",
         "safe-stable-stringify": "^2.3.1",
-        "sonic-boom": "^3.7.0",
-        "thread-stream": "^2.6.0"
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
       },
       "bin": {
         "pino": "bin.js"
       }
     },
     "node_modules/pino-abstract-transport": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
-      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "readable-stream": "^4.0.0",
         "split2": "^4.0.0"
       }
     },
     "node_modules/pino-http": {
-      "version": "8.6.1",
-      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-8.6.1.tgz",
-      "integrity": "sha512-J0hiJgUExtBXP2BjrK4VB305tHXS31sCmWJ9XJo2wPkLHa1NFPuW4V9wjG27PAc2fmBCigiNhQKpvrx+kntBPA==",
-      "peer": true,
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-10.4.0.tgz",
+      "integrity": "sha512-vjQsKBE+VN1LVchjbfLE7B6nBeGASZNRNKsR68VS0DolTm5R3zo+47JX1wjm0O96dcbvA7vnqt8YqOWlG5nN0w==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "get-caller-file": "^2.0.5",
-        "pino": "^8.17.1",
-        "pino-std-serializers": "^6.2.2",
-        "process-warning": "^3.0.0"
+        "pino": "^9.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^4.0.0"
       }
     },
+    "node_modules/pino-http/node_modules/process-warning": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
+      "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/pino-std-serializers": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
-      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pino/node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/pirates": {
       "version": "4.0.6",
@@ -6170,14 +6012,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -6187,7 +6021,8 @@
     "node_modules/process-warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
-      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ=="
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
+      "dev": true
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -6278,7 +6113,8 @@
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
-      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "dev": true
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -6310,25 +6146,11 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true
     },
-    "node_modules/readable-stream": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
     "node_modules/real-require": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
       "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "dev": true,
       "engines": {
         "node": ">= 12.13.0"
       }
@@ -6515,6 +6337,7 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -6523,6 +6346,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6551,6 +6375,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
       "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -6744,9 +6569,11 @@
       }
     },
     "node_modules/sonic-boom": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
-      "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
       }
@@ -6774,6 +6601,8 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">= 10.x"
       }
@@ -6821,14 +6650,6 @@
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-length": {
@@ -7044,9 +6865,11 @@
       "dev": true
     },
     "node_modules/thread-stream": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
-      "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "real-require": "^0.2.0"
       }
@@ -7156,7 +6979,8 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -7227,6 +7051,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/uid/-/uid-2.0.2.tgz",
       "integrity": "sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==",
+      "dev": true,
       "dependencies": {
         "@lukeed/csprng": "^1.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -44,8 +44,9 @@
   "peerDependencies": {
     "@nestjs/common": "^10.0.0 || ^11.0.0",
     "@nestjs/core": "^10.0.0 || ^11.0.0",
-    "nestjs-pino": ">=3.5.0",
-    "pino": "^8.0.0",
+    "nestjs-pino": ">=3.5.0 || ^4.0.0",
+    "pino": "^8.0.0 || ^9.0.0",
+    "pino-http": "^8.0.0 || ^9.0.0 || ^10.0.0",
     "reflect-metadata": ">=0.1.13",
     "rxjs": "^7.0.0"
   },
@@ -67,7 +68,9 @@
     "express": "^4.18.2",
     "fastify": "^4.0.0",
     "jest": "^29.7.0",
-    "pino": "^8.0.0",
+    "nestjs-pino": "^4.4.0",
+    "pino": "^9.7.0",
+    "pino-http": "^10.4.0",
     "prettier": "^3.4.1",
     "rimraf": "^5.0.0",
     "rxjs": "^7.0.0",


### PR DESCRIPTION
### 🚀 Update peer deps to use Pino V9

#### changes:

* update `peerDependencies` to enable usage of pino v9, pino-http v10, nestjs-pino v4
* update `devDependencies`
