### PR TITLE
doc: update the documentation for WithContext to prevent bugs

### DIFF
--- a/src/decorators/with-context.decorator.ts
+++ b/src/decorators/with-context.decorator.ts
@@ -7,20 +7,20 @@ import { ContextStore } from '../store/context-store';
  *
  * @example
  * ```typescript
- * @WithContext()
  * @MessagePattern('user.created')
+ * @WithContext()
  * async handleUserCreated(data: CreateUserDto) {
  *   this.logger.log('Processing user creation');
  * }
  *
- * @WithContext({ userId: 'user_123' })
  * @Cron('0 0 * * *')
+ * @WithContext({ userId: 'user_123' })
  * async dailyReport() {
  *   this.logger.log('Running daily report');
  * }
  *
- * @WithContext(() => ({ correlationId: uuid(), service: 'UserService' }))
  * @MessagePattern('user.validate')
+ * @WithContext(() => ({ correlationId: uuid(), service: 'UserService' }))
  * async validateUser(data: ValidateUserDto) {
  *   this.logger.log('Validating user'); // Fresh correlationId each call
  * }


### PR DESCRIPTION
I have noticed a bug with #17 in running environment that the decorator placing is crucial as the decorator `EventPattern` uses the method descriptor for reflection so it is crucial that it will be registered last (appear first in the decorators)

```typescript
@EventPattern(...)
@WithContext()
handler() {}

// actually what happened EventPattern(WithContext(Handler()))
```

Reference
[EventPattern decorator](https://github.com/nestjs/nest/blob/master/packages/microservices/decorators/event-pattern.decorator.ts)
[Stackoverflow](https://stackoverflow.com/questions/46758235/what-is-the-decorator-running-order)