### PR TITLE
fix: enhance error and fatal logs to handle object messages

### DIFF
--- a/src/context-logger.spec.ts
+++ b/src/context-logger.spec.ts
@@ -117,6 +117,72 @@ describe('ContextLogger', () => {
         MODULE_NAME
       );
     });
+
+    describe('object as message parameter', () => {
+      it.each(['error', 'fatal'])('should extract message property from object and include object fields in bindings', (method) => {
+        const messageObject = { message: 'Error from object', code: 'ERR_001', details: 'Some details' };
+
+        contextLogger[method](messageObject as any);
+
+        expect(mockLogger[method]).toHaveBeenCalledWith(
+          { message: 'Error from object', code: 'ERR_001', details: 'Some details', ...CONTEXT },
+          'Error from object',
+          MODULE_NAME
+        );
+      });
+
+      it.each(['error', 'fatal'])('should JSON stringify object when no message property exists', (method) => {
+        const messageObject = { code: 'ERR_001', details: 'Some details' };
+
+        contextLogger[method](messageObject as any);
+
+        expect(mockLogger[method]).toHaveBeenCalledWith(
+          { code: 'ERR_001', details: 'Some details', ...CONTEXT },
+          JSON.stringify(messageObject),
+          MODULE_NAME
+        );
+      });
+
+      it.each(['error', 'fatal'])('should handle object message with Error as second parameter', (method) => {
+        const messageObject = { message: 'Error from object', code: 'ERR_001' };
+        const error = new Error('Test error');
+
+        contextLogger[method](messageObject as any, error);
+
+        expect(mockLogger[method]).toHaveBeenCalledWith(
+          { err: error, message: 'Error from object', code: 'ERR_001', ...CONTEXT },
+          'Error from object',
+          MODULE_NAME
+        );
+      });
+
+      it.each(['error', 'fatal'])('should handle object message with bindings as second parameter', (method) => {
+        const messageObject = { message: 'Error from object', code: 'ERR_001' };
+        const bindings = { someBinding: 'value' };
+
+        contextLogger[method](messageObject as any, bindings);
+
+        expect(mockLogger[method]).toHaveBeenCalledWith(
+          { message: 'Error from object', code: 'ERR_001', someBinding: 'value', ...CONTEXT },
+          'Error from object',
+          MODULE_NAME
+        );
+      });
+
+      it.each(['error', 'fatal'])('should handle object message with Error and bindings', (method) => {
+        const messageObject = { message: 'Error from object', code: 'ERR_001' };
+        const error = new Error('Test error');
+        const bindings = { someBinding: 'value' };
+
+        contextLogger[method](messageObject as any, error, bindings);
+
+        expect(mockLogger[method]).toHaveBeenCalledWith(
+          { err: error, message: 'Error from object', code: 'ERR_001', someBinding: 'value', ...CONTEXT },
+          'Error from object',
+          MODULE_NAME
+        );
+      });
+    });
   });
 
   describe('static methods', () => {

--- a/src/context-logger.ts
+++ b/src/context-logger.ts
@@ -61,6 +61,16 @@ export class ContextLogger {
     let error: Error | undefined;
     const adaptedBindings: Bindings = {};
 
+    if (typeof message === 'object') {
+      Object.assign(adaptedBindings, message);
+
+      if ((message as object).hasOwnProperty('message')) {
+        message = (message as any).message as string;
+      } else {
+        message = JSON.stringify(message);
+      }
+    }
+
     if (errorOrBindings instanceof Error) {
       error = errorOrBindings;
       if (bindings) {
@@ -82,6 +92,16 @@ export class ContextLogger {
   error(message: string, errorOrBindings?: Error | Bindings, bindings?: Bindings): void {
     let error: Error | undefined;
     const adaptedBindings: Bindings = {};
+
+    if (typeof message === 'object') {
+      Object.assign(adaptedBindings, message);
+
+      if ((message as object).hasOwnProperty('message')) {
+        message = (message as any).message as string;
+      } else {
+        message = JSON.stringify(message);
+      }
+    }
 
     if (errorOrBindings instanceof Error) {
       error = errorOrBindings;


### PR DESCRIPTION
Add support for object messages in `error` and `fatal` methods.

Sometimes NestJS bootstrap error logs are objects rather then strings, so the logs are printed like this:
<img width="616" height="36" alt="image" src="https://github.com/user-attachments/assets/927fbdac-1cd9-475b-8747-fbceb6f9b8ae" />

and with the suggested fix:
<img width="792" height="60" alt="image" src="https://github.com/user-attachments/assets/a296340f-97b5-45d7-968b-c7715ddc7c41" />
