### PR TITLE
fix: update middleware route pattern for path-to-regexp v8 compatibility

### DIFF
--- a/examples/nestjs11-example/src/app.module.ts
+++ b/examples/nestjs11-example/src/app.module.ts
@@ -20,6 +20,6 @@ export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
     consumer
       .apply(VersionMiddleware)
-      .forRoutes('*');
+      .forRoutes('{*path}');
   }
 } 

--- a/examples/nestjs11-example/src/app.module.ts
+++ b/examples/nestjs11-example/src/app.module.ts
@@ -20,6 +20,6 @@ export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
     consumer
       .apply(VersionMiddleware)
-      .forRoutes('{*path}');
+      .forRoutes('*');
   }
 } 

--- a/src/context-logger.module.spec.ts
+++ b/src/context-logger.module.spec.ts
@@ -172,12 +172,13 @@ describe('ContextLoggerModule', () => {
       // Get and execute the factory to verify its output
       const factory = (LoggerModule.forRootAsync as jest.Mock).mock.calls[0][0].useFactory;
       const config = await factory();
-      expect(config).toEqual({
+      expect(config).toMatchObject({
         pinoHttp: {
           level: 'info',
           autoLogging: false,
         }
       });
+      expect(config.forRoutes).toBeDefined();
     });
 
     describe('createPinoConfig', () => {
@@ -190,12 +191,13 @@ describe('ContextLoggerModule', () => {
       it('should return default config when empty options provided', () => {
         const result = createPinoConfig({});
         
-        expect(result).toEqual({
+        expect(result).toMatchObject({
           pinoHttp: {
             autoLogging: false,
             level: 'info'
           }
         });
+        expect(result.forRoutes).toBeDefined();
       });
   
       it('should merge pinoHttp options with defaults', () => {
@@ -205,16 +207,17 @@ describe('ContextLoggerModule', () => {
             customKey: 'value'
           }
         };
-  
+
         const result = createPinoConfig(options);
-  
-        expect(result).toEqual({
+
+        expect(result).toMatchObject({
           pinoHttp: {
             autoLogging: false,  // default preserved
             level: 'debug',      // overridden
             customKey: 'value'   // new value added
           }
         });
+        expect(result.forRoutes).toBeDefined();
       });
   
       it('should allow overriding default pinoHttp values', () => {
@@ -224,15 +227,16 @@ describe('ContextLoggerModule', () => {
             level: 'error'
           }
         };
-  
+
         const result = createPinoConfig(options);
-  
-        expect(result).toEqual({
+
+        expect(result).toMatchObject({
           pinoHttp: {
             autoLogging: true,
             level: 'error'
           }
         });
+        expect(result.forRoutes).toBeDefined();
       });
     });
 

--- a/src/context-logger.module.ts
+++ b/src/context-logger.module.ts
@@ -4,6 +4,7 @@ import {
   MiddlewareConsumer,
   NestModule,
   Inject,
+  RequestMethod,
 } from '@nestjs/common';
 import { LoggerModule, Logger as NestJSPinoLogger } from 'nestjs-pino';
 import { RequestInterceptor } from './interceptors/request.interceptor';
@@ -30,10 +31,11 @@ export class ContextLoggerModule implements NestModule {
 
   private static createPinoConfig(options: ContextLoggerFactoryOptions): ContextLoggerFactoryOptions {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { enrichContext, pinoHttp = {}, ...restOptions } = options;
+    const { enrichContext, pinoHttp = {}, forRoutes, ...restOptions } = options;
     
     return {
       ...restOptions,
+      forRoutes: forRoutes ?? [{ path: getMiddlewareCatchAllRoute(), method: RequestMethod.ALL }],
       pinoHttp: {
         autoLogging: false,
         level: 'info',

--- a/src/context-logger.module.ts
+++ b/src/context-logger.module.ts
@@ -8,6 +8,7 @@ import {
 import { LoggerModule, Logger as NestJSPinoLogger } from 'nestjs-pino';
 import { RequestInterceptor } from './interceptors/request.interceptor';
 import { InitContextMiddleware } from './middlewares/context.middleware';
+import { getMiddlewareCatchAllRoute } from './middlewares/middleware-catch-all.route';
 import { ContextLogger } from './context-logger';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import { ContextLoggerAsyncOptions, ContextLoggerFactoryOptions } from './interfaces/context-logger.interface';
@@ -24,7 +25,7 @@ export class ContextLoggerModule implements NestModule {
     consumer
       .apply(InitContextMiddleware)
       .exclude(...excludePatterns)
-      .forRoutes('{*path}');
+      .forRoutes(getMiddlewareCatchAllRoute());
   }
 
   private static createPinoConfig(options: ContextLoggerFactoryOptions): ContextLoggerFactoryOptions {

--- a/src/context-logger.module.ts
+++ b/src/context-logger.module.ts
@@ -24,7 +24,7 @@ export class ContextLoggerModule implements NestModule {
     consumer
       .apply(InitContextMiddleware)
       .exclude(...excludePatterns)
-      .forRoutes('*');
+      .forRoutes('{*path}');
   }
 
   private static createPinoConfig(options: ContextLoggerFactoryOptions): ContextLoggerFactoryOptions {

--- a/src/middlewares/middleware-catch-all.route.ts
+++ b/src/middlewares/middleware-catch-all.route.ts
@@ -1,7 +1,7 @@
 /**
  * Wildcard path for `MiddlewareConsumer.forRoutes`.
  * Nest 11+ uses path-to-regexp v8: bare `*` can emit LegacyRouteConverter warnings; `{*path}` is the v8 splat.
- * Nest 10 and Fastify’s middie stack do not reliably support `{*path}`.
+ * Nest 10 and Fastify's middie stack do not reliably support `{*path}`.
  */
 export function getMiddlewareCatchAllRoute(): string {
   try {

--- a/src/middlewares/middleware-catch-all.route.ts
+++ b/src/middlewares/middleware-catch-all.route.ts
@@ -1,0 +1,15 @@
+/**
+ * Wildcard path for `MiddlewareConsumer.forRoutes`.
+ * Nest 11+ uses path-to-regexp v8: bare `*` can emit LegacyRouteConverter warnings; `{*path}` is the v8 splat.
+ * Nest 10 and Fastify’s middie stack do not reliably support `{*path}`.
+ */
+export function getMiddlewareCatchAllRoute(): string {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { version } = require('@nestjs/core/package.json') as { version: string };
+    const major = Number.parseInt(version.split('.', 1)[0]!, 10);
+    return Number.isFinite(major) && major >= 11 ? '{*path}' : '*';
+  } catch {
+    return '*';
+  }
+}


### PR DESCRIPTION
## Summary

NestJS 11 uses `path-to-regexp` v8 which requires named parameters for wildcards. The old `*` syntax triggers a deprecation warning during bootstrap:

```
WARN [LegacyRouteConverter] Unsupported route path: "/api/v1/*". In previous versions, the symbols ?, *, and + were used to denote optional or repeating path parameters. The latest version of "path-to-regexp" now requires the use of named parameters. For example, instead of using a route like /users/* to capture all routes starting with "/users", you should use /users/*path. For more details, refer to the migration guide. Attempting to auto-convert...
```

This warning appears multiple times during application startup when using `nestjs-context-logger` with NestJS 11.

## Root Cause

The warning was triggered by **two** middleware registrations using bare `*`:

1. `ContextLoggerModule.configure()` calling `.forRoutes('*')`
2. `nestjs-pino`'s `LoggerModule` default `forRoutes: [{ path: '*', method: ALL }]`

Simply changing to `{*path}` everywhere breaks NestJS 10 and Fastify's `@fastify/middie` which use an older `path-to-regexp` that doesn't understand the new syntax.

## Changes

- **New helper** `getMiddlewareCatchAllRoute()` that detects `@nestjs/core` version:
  - Returns `'{*path}'` for NestJS 11+ (path-to-regexp v8)
  - Returns `'*'` for NestJS 10 (path-to-regexp v7)
- **Updated `ContextLoggerModule`** to use the helper in `.forRoutes()`
- **Pass `forRoutes` to `LoggerModule`** via `createPinoConfig()` to override `nestjs-pino`'s default

## Why Version Detection?

According to the [NestJS migration guide](https://docs.nestjs.com/migration-guide#fastify-middleware-registration), `{*path}` is the correct syntax for v8. However:

- NestJS 10 + Fastify's middie stack **does not** support `{*path}` (throws parse errors)
- The library supports both `^10` and `^11` peer versions

Version detection ensures both work without warnings.

## Backward Compatibility

- **NestJS 11**: Uses `{*path}` - no warnings
- **NestJS 10**: Uses `*` - works correctly (warnings only appear on v11)

## Testing

- Tested with `npm ci` (NestJS 10.4.13 from lockfile) - all 117 tests pass
- Tested with NestJS 11.1.x override - all 117 tests pass
- Verified locally: no `LegacyRouteConverter` warnings on NestJS 11

## Related Issues

- NestJS issue: https://github.com/nestjs/nest/issues/14894
- NestJS migration guide: https://docs.nestjs.com/migration-guide#fastify-middleware-registration